### PR TITLE
Use relative paths for Jarvik scripts

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
-cd ~/Jarvik_RAG || exit
+DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$DIR" || exit
 source venv/bin/activate
 echo "✅ Aktivováno virtuální prostředí JARVIK (venv)"

--- a/load.sh
+++ b/load.sh
@@ -1,11 +1,13 @@
-cat << 'EOF' >> ~/.bashrc
+DIR="$(cd "$(dirname "$0")" && pwd)"
+
+cat >> ~/.bashrc <<EOF
 
 # 🚀 Alias příkazy pro JARVIK
-alias jarvik='bash ~/Jarvik_RAG/activate.sh'
-alias jarvik-start='bash ~/Jarvik_RAG/start.sh'
-alias jarvik-status='bash ~/Jarvik_RAG/status.sh'
-alias jarvik-install='bash ~/Jarvik_RAG/install_jarvik.sh'
-alias jarvik-flask='source ~/Jarvik_RAG/venv/bin/activate && python ~/Jarvik_RAG/main.py'
+alias jarvik='bash $DIR/activate.sh'
+alias jarvik-start='bash $DIR/start.sh'
+alias jarvik-status='bash $DIR/status.sh'
+alias jarvik-install='bash $DIR/install_jarvik.sh'
+alias jarvik-flask='source $DIR/venv/bin/activate && python $DIR/main.py'
 
 EOF
 


### PR DESCRIPTION
## Summary
- use the script location for alias definitions in `load.sh`
- update `activate.sh` to work from its own directory

## Testing
- `python3 -m py_compile main.py rag_engine.py`
- `shellcheck load.sh activate.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685926c1af8083228157c827449db62f