### PR TITLE
Fix /ask route missing JSON handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -29,8 +29,8 @@ def append_to_memory(user_msg, ai_response):
 
 @app.route("/ask", methods=["POST"])
 def ask():
-    data = request.get_json()
-    message = data.get("message", "")
+    data = request.get_json(silent=True)
+    message = (data or {}).get("message", "")
     debug_log.clear()
 
     memory_context = load_memory()


### PR DESCRIPTION
## Summary
- handle missing JSON in `/ask` with `request.get_json(silent=True)`
- safeguard `data` lookup so an empty dict is used if no JSON was supplied

## Testing
- `python -m py_compile main.py rag_engine.py`


------
https://chatgpt.com/codex/tasks/task_b_685934de6f18832294d3942c7ee3ff9f