### PR TITLE
Improve install script path handling

### DIFF
--- a/install_jarvik.sh
+++ b/install_jarvik.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$DIR" || exit
+set -e
 
 echo "🔧 Instalace závislostí pro Jarvika..."
 


### PR DESCRIPTION
## Summary
- ensure `install_jarvik.sh` runs from its own directory
- enable immediate exit on error

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_68594033ee208322b8baf38b8f7bebbe