### PR TITLE
Add uninstall script with cleanup option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# Jarvik
+
+This repository contains scripts to run the Jarvik assistant locally.
+
+## Installation
+
+Install dependencies and create the virtual environment:
+
+```bash
+bash install_jarvik.sh
+```
+
+If you need a fresh start, run the installer with `--clean` to first remove
+any previous environment:
+
+```bash
+bash install_jarvik.sh --clean
+```
+
+## Running Jarvik
+
+Activate the environment and start all services:
+
+```bash
+bash run_jarvik.sh
+```
+
+## Uninstall
+
+To stop running services and remove generated files and aliases run:
+
+```bash
+bash uninstall_jarvik.sh
+```
+
+This stops running processes (Ollama, Mistral and Flask), removes the
+`venv/` and `memory/` directories and cleans the Jarvik aliases from
+`~/.bashrc`.

--- a/install_jarvik.sh
+++ b/install_jarvik.sh
@@ -3,6 +3,11 @@ DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$DIR" || exit
 set -e
 
+# Optional cleanup
+if [ "$1" = "--clean" ]; then
+  bash "$DIR/uninstall_jarvik.sh"
+fi
+
 echo "🔧 Instalace závislostí pro Jarvika..."
 
 # Vytvoření složek

--- a/uninstall_jarvik.sh
+++ b/uninstall_jarvik.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$DIR" || exit
+set -e
+
+echo "🗑️ Odinstalace Jarvika..."
+
+# Kill running processes
+pkill -f "ollama serve" 2>/dev/null && echo "Zastaven ollama serve" || true
+pkill -f "ollama run mistral" 2>/dev/null && echo "Zastaven mistral" || true
+pkill -f "python3 main.py" 2>/dev/null && echo "Zastaven Flask" || true
+
+# Remove directories and logs
+rm -rf venv memory
+find . -name "__pycache__" -type d -exec rm -rf {} + 2>/dev/null
+rm -f *.log
+
+# Remove aliases from ~/.bashrc
+sed -i '/# 🚀 Alias příkazy pro JARVIK/,+6d' ~/.bashrc
+
+echo "✅ Jarvik odstraněn."


### PR DESCRIPTION
## Summary
- add a helper script `uninstall_jarvik.sh` to clean up Jarvik processes
- allow `install_jarvik.sh --clean` to run the uninstall script first
- document installation, cleanup and uninstall in a new README

## Testing
- `bash install_jarvik.sh --clean` *(fails: Could not fetch packages)*
- `bash -n install_jarvik.sh`
- `bash -n uninstall_jarvik.sh`


------
https://chatgpt.com/codex/tasks/task_b_685942dd7448832284dd110bc11dbfb9