### PR TITLE
Avoid duplicating Jarvik aliases in bashrc

### DIFF
--- a/load.sh
+++ b/load.sh
@@ -1,6 +1,8 @@
 DIR="$(cd "$(dirname "$0")" && pwd)"
 
-cat >> ~/.bashrc <<EOF
+# Add Jarvik aliases only if they aren't already present
+if ! grep -q "# 🚀 Alias příkazy pro JARVIK" ~/.bashrc; then
+  cat >> ~/.bashrc <<EOF
 
 # 🚀 Alias příkazy pro JARVIK
 alias jarvik='bash $DIR/activate.sh'
@@ -10,6 +12,7 @@ alias jarvik-install='bash $DIR/install_jarvik.sh'
 alias jarvik-flask='source $DIR/venv/bin/activate && python $DIR/main.py'
 
 EOF
+fi
 
 # Načtení změn
 source ~/.bashrc


### PR DESCRIPTION
## Summary
- prevent duplicate Jarvik aliases when running `load.sh`

## Testing
- `bash -n load.sh`


------
https://chatgpt.com/codex/tasks/task_b_685943d2741c83229ff5e907f802e679