### PR TITLE
Update run_jarvik and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ or via the alias:
 ```bash
 jarvik-status
 ```
+The script expects the Mistral model to be running persistently via
+`ollama run mistral`.
 
 ## Stopping Jarvik and Uninstall
 

--- a/run_jarvik.sh
+++ b/run_jarvik.sh
@@ -7,8 +7,8 @@ cd "$(dirname "$0")" || exit
 
 # Aktivuj venv
 if [[ -z "$VIRTUAL_ENV" ]]; then
-  echo -e "${GREEN}✅ Aktivováno virtuální prostředí JARVIK (venv)${NC}"
   source venv/bin/activate
+  echo -e "${GREEN}✅ Aktivováno virtuální prostředí JARVIK (venv)${NC}"
 fi
 
 # Spustit Ollama
@@ -18,14 +18,10 @@ if ! pgrep -f "ollama serve" > /dev/null; then
   sleep 3
 fi
 
-# Spustit model mistral pomocí jednoho dotazu (trik na načtení do paměti)
+# Spustit model mistral, pokud neběží
 if ! curl -s http://localhost:11434/api/tags | grep -q '"name":"mistral"'; then
-  echo -e "${GREEN}🧠 Spouštím model mistral přes API...${NC}"
-  curl -s http://localhost:11434/api/generate -d '{
-    "model": "mistral",
-    "prompt": "ping",
-    "stream": false
-  }' > /dev/null
+  echo -e "${GREEN}🧠 Spouštím model mistral...${NC}"
+  nohup ollama run mistral > /dev/null 2>&1 &
   sleep 2
 fi
 


### PR DESCRIPTION
## Summary
- ensure the virtualenv activation message appears after sourcing in `run_jarvik.sh`
- persistently run Mistral via `nohup ollama run mistral` instead of the previous API trick
- document that `jarvik-status` expects a running Mistral process

## Testing
- `bash -n run_jarvik.sh`
- `bash -n start.sh status.sh uninstall_jarvik.sh`

------
https://chatgpt.com/codex/tasks/task_b_68594e1aec80832280389ceb5bea75d6