### PR TITLE
Add timestamp to conversation log

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -92,10 +92,11 @@
       });
 
       const data = await res.json();
+      const timestamp = new Date().toLocaleTimeString();
 
       document.getElementById("response").textContent = data.response || "❌ Chyba odpovědi";
       document.getElementById("debug").textContent = data.debug ? data.debug.join("\n") : "(žádný debug)";
-      conversationLog += `👤 ${msg}\n🤖 ${data.response}\n\n`;
+      conversationLog += `[${timestamp}] 👤 ${msg}\n[${timestamp}] 🤖 ${data.response}\n\n`;
       document.getElementById("log").textContent = conversationLog;
 
       document.getElementById("message").value = "";


### PR DESCRIPTION
## Summary
- generate a timestamp when each answer arrives
- show the timestamp with both the question and reply in the conversation history

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685a3071db088322a6df5912e26994ce