### PR TITLE
Add upgrade script

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,13 @@ bash monitor.sh
 
 The script refreshes every two seconds and shows the last lines from
 `flask.log`, `mistral.log` and `ollama.log` produced by `start.sh`.
+
+## Upgrade
+
+To download the latest version, reinstall and start Jarvik automatically run:
+
+```bash
+bash upgrade.sh
+```
+
+The script pulls the newest repository files, performs an uninstall, installs the dependencies again and starts all components.

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$DIR" || exit
+
+GREEN='\033[1;32m'
+NC='\033[0m'
+
+# Download latest version if possible
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  if [ -n "$(git remote)" ]; then
+    echo -e "${GREEN}🔄 Stahuji nejnovější verzi...${NC}"
+    git pull
+  else
+    echo -e "${GREEN}⚠️  Git remote není nastaven, stahování vynecháno.${NC}"
+  fi
+else
+  echo -e "${GREEN}⚠️  Adresář není git repozitář, stahování vynecháno.${NC}"
+fi
+
+# Reinstall
+bash uninstall_jarvik.sh
+bash install_jarvik.sh
+
+# Start automatically
+bash start.sh
+
+echo -e "${GREEN}✅ Upgrade dokončen.${NC}"


### PR DESCRIPTION
## Summary
- add `upgrade.sh` to automate reinstalling and restarting Jarvik
- document the upgrade process in the README

## Testing
- `bash -n upgrade.sh`


------
https://chatgpt.com/codex/tasks/task_b_685a32b03d0083228cb2aad3715646e4