### PR TITLE
Improve Jarvik helper scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ To launch all components run:
 bash start.sh
 ```
 
-With the aliases loaded you can simply type:
+The script checks for required commands and automatically downloads the
+`mistral` model if it is missing. With the aliases loaded you can simply type:
 
 ```bash
 jarvik-start
@@ -96,7 +97,7 @@ To download the latest version, reinstall and start Jarvik automatically run:
 bash upgrade.sh
 ```
 
-The script pulls the newest repository files, performs an uninstall, installs the dependencies again and starts all components.
+The script pulls the newest repository files, performs an uninstall, installs the dependencies again, reloads the shell aliases and starts all components.
 
 ## License
 

--- a/manual
+++ b/manual
@@ -28,6 +28,7 @@ bash start.sh
 jarvik-start
 ```
 Skript aktivuje virtuální prostředí, spustí Ollamu, model Mistral a nakonec Flask server na portu 8010.
+Pokud model chybí, stáhne se automaticky.
 
 ## Stav běžících služeb
 
@@ -53,3 +54,11 @@ Pro jednorázové spuštění všech komponent slouží skript `run_jarvik.sh`, 
 ```bash
 bash run_jarvik.sh
 ```
+
+## Upgrade
+
+Nejnovější verzi můžete stáhnout a nainstalovat skriptem `upgrade.sh`:
+```bash
+bash upgrade.sh
+```
+Skript stáhne nové soubory z repozitáře, provede odinstalování, znovu nainstaluje závislosti, obnoví aliasy v `~/.bashrc` a spustí Jarvika.

--- a/run_jarvik.sh
+++ b/run_jarvik.sh
@@ -1,27 +1,52 @@
 #!/bin/bash
 
 GREEN='\033[1;32m'
+RED='\033[1;31m'
 NC='\033[0m'
 
 cd "$(dirname "$0")" || exit
 
 # Aktivuj venv
 if [[ -z "$VIRTUAL_ENV" ]]; then
-  source venv/bin/activate
-  echo -e "${GREEN}✅ Aktivováno virtuální prostředí JARVIK (venv)${NC}"
+  if [ -f venv/bin/activate ]; then
+    source venv/bin/activate
+    echo -e "${GREEN}✅ Aktivováno virtuální prostředí JARVIK (venv)${NC}"
+  else
+    echo -e "${RED}❌ Chybí virtuální prostředí venv/. Spusťte install_jarvik.sh.${NC}"
+    exit 1
+  fi
 fi
+
+# Kontrola potřebných příkazů
+for cmd in ollama python3 curl; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo -e "${RED}❌ Chybí příkaz $cmd. Nainstalujte jej a spusťte znovu.${NC}"
+    exit 1
+  fi
+done
 
 # Spustit Ollama
 if ! pgrep -f "ollama serve" > /dev/null; then
   echo -e "${GREEN}🚀 Spouštím Ollama...${NC}"
-  nohup ollama serve > /dev/null 2>&1 &
-  sleep 3
+  nohup ollama serve > ollama.log 2>&1 &
+  for i in {1..10}; do
+    if curl -s http://localhost:11434/api/tags >/dev/null 2>&1; then
+      break
+    fi
+    sleep 1
+  done
+fi
+
+# Zajistit stažení modelu mistral
+if ! ollama list 2>/dev/null | grep -q '^mistral'; then
+  echo -e "${GREEN}⬇️  Stahuji model mistral...${NC}"
+  ollama pull mistral >> ollama.log 2>&1
 fi
 
 # Spustit model mistral, pokud neběží
-if ! curl -s http://localhost:11434/api/tags | grep -q '"name":"mistral"'; then
+if ! pgrep -f "ollama run mistral" > /dev/null; then
   echo -e "${GREEN}🧠 Spouštím model mistral...${NC}"
-  nohup ollama run mistral > /dev/null 2>&1 &
+  nohup ollama run mistral > mistral.log 2>&1 &
   sleep 2
 fi
 

--- a/start.sh
+++ b/start.sh
@@ -1,25 +1,50 @@
 #!/bin/bash
-
-GREEN='\033[1;32m'
-NC='\033[0m'
+GREEN="\033[1;32m"
+RED="\033[1;31m"
+NC="\033[0m"
 
 cd "$(dirname "$0")" || exit
 
 # Aktivovat venv, pokud ještě není aktivní
 if [ -z "$VIRTUAL_ENV" ]; then
-  source venv/bin/activate
-  echo -e "${GREEN}✅ Aktivováno virtuální prostředí${NC}"
+  if [ -f venv/bin/activate ]; then
+    source venv/bin/activate
+    echo -e "${GREEN}✅ Aktivováno virtuální prostředí${NC}"
+  else
+    echo -e "${RED}❌ Chybí virtuální prostředí venv/. Spusťte install_jarvik.sh.${NC}"
+    exit 1
+  fi
 fi
+
+# Zkontrolovat dostupnost příkazů
+for cmd in ollama python3 curl; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo -e "${RED}❌ Chybí příkaz $cmd. Nainstalujte jej a spusťte znovu.${NC}"
+    exit 1
+  fi
+done
 
 # Spustit Ollama, pokud neběží
 if ! pgrep -f "ollama serve" > /dev/null; then
   echo -e "${GREEN}🚀 Spouštím Ollama...${NC}"
   nohup ollama serve > ollama.log 2>&1 &
-  sleep 2
+  # Počkej na zpřístupnění API
+  for i in {1..10}; do
+    if curl -s http://localhost:11434/api/tags >/dev/null 2>&1; then
+      break
+    fi
+    sleep 1
+  done
+fi
+
+# Ověřit dostupnost modelu mistral a případně jej stáhnout
+if ! ollama list 2>/dev/null | grep -q '^mistral'; then
+  echo -e "${GREEN}⬇️  Stahuji model mistral...${NC}"
+  ollama pull mistral >> ollama.log 2>&1
 fi
 
 # Spustit mistral, pokud neběží
-if ! curl -s http://localhost:11434/api/tags | grep -q '"name": "mistral"'; then
+if ! pgrep -f "ollama run mistral" > /dev/null; then
   echo -e "${GREEN}🧠 Spouštím model mistral...${NC}"
   nohup ollama run mistral > mistral.log 2>&1 &
   sleep 2

--- a/status.sh
+++ b/status.sh
@@ -21,7 +21,16 @@ else
 fi
 
 # Flask port 8010
-if ss -tuln | grep -q ":8010"; then
+if command -v ss >/dev/null 2>&1; then
+  ss -tuln | grep -q ":8010"
+  port_check=$?
+elif command -v nc >/dev/null 2>&1; then
+  nc -z localhost 8010 >/dev/null 2>&1
+  port_check=$?
+else
+  port_check=1
+fi
+if [ "$port_check" = 0 ]; then
   echo -e "✅ Flask běží (port 8010)"
 else
   echo -e "❌ Flask (port 8010) neběží"

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -18,9 +18,12 @@ else
   echo -e "${GREEN}⚠️  Adresář není git repozitář, stahování vynecháno.${NC}"
 fi
 
-# Reinstall
+# Reinstall dependencies
 bash uninstall_jarvik.sh
 bash install_jarvik.sh
+
+# Re-add shell aliases
+bash load.sh
 
 # Start automatically
 bash start.sh


### PR DESCRIPTION
## Summary
- add automatic pull for mistral model in startup scripts
- wait for the Ollama API before launching Mistral
- include dependency checks in `run_jarvik.sh`
- update docs about automatic model download
- **reload aliases when running `upgrade.sh`**

## Testing
- `bash start.sh` *(fails: missing venv)*
- `bash status.sh`
- `bash run_jarvik.sh` *(fails: missing venv)*
- `bash upgrade.sh` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_685a5a9640c883229b1ad220934d5eab