### PR TITLE
Improve status messaging for Mistral

### DIFF
--- a/status.sh
+++ b/status.sh
@@ -18,6 +18,11 @@ if pgrep -f "ollama run mistral" > /dev/null; then
   echo -e "✅ Model Mistral běží"
 else
   echo -e "❌ Model Mistral NEběží"
+  if command -v ollama >/dev/null 2>&1; then
+    echo "   Spusťte jej příkazem 'ollama run mistral &' nebo 'jarvik-start'."
+  else
+    echo "   Chybí program 'ollama'."
+  fi
 fi
 
 # Flask port 8010


### PR DESCRIPTION
## Summary
- update `status.sh` to give a helpful hint when Mistral isn't detected

## Testing
- `bash status.sh`

------
https://chatgpt.com/codex/tasks/task_b_685a6e8efd3483228f4ed64bbb7b6677