### PR TITLE
Make model name configurable

### DIFF
--- a/uninstall_jarvik.sh
+++ b/uninstall_jarvik.sh
@@ -2,12 +2,13 @@
 DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$DIR" || exit
 set -e
+MODEL_NAME=${MODEL_NAME:-jarvik-mistral}
 
 echo "🗑️ Odinstalace Jarvika..."
 
 # Kill running processes
 pkill -f "ollama serve" 2>/dev/null && echo "Zastaven ollama serve" || true
-pkill -f "ollama run mistral" 2>/dev/null && echo "Zastaven mistral" || true
+pkill -f "ollama run $MODEL_NAME" 2>/dev/null && echo "Zastaven $MODEL_NAME" || true
 pkill -f "python3 main.py" 2>/dev/null && echo "Zastaven Flask" || true
 
 # Remove directories and logs

--- a/watchdog.sh
+++ b/watchdog.sh
@@ -2,6 +2,7 @@
 GREEN="\033[1;32m"
 RED="\033[1;31m"
 NC="\033[0m"
+MODEL_NAME=${MODEL_NAME:-jarvik-mistral}
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$DIR" || exit
@@ -21,9 +22,9 @@ check_ollama() {
 }
 
 check_mistral() {
-  if ! pgrep -f "ollama run mistral" > /dev/null; then
-    echo -e "${RED}⚠️  Mistral neběží. Restartuji...${NC}"
-    nohup ollama run mistral >> mistral.log 2>&1 &
+  if ! pgrep -f "ollama run $MODEL_NAME" > /dev/null; then
+    echo -e "${RED}⚠️  Model $MODEL_NAME neběží. Restartuji...${NC}"
+    nohup ollama run "$MODEL_NAME" >> mistral.log 2>&1 &
   fi
 }
 


### PR DESCRIPTION
## Summary
- allow specifying model name in `watchdog.sh`
- restart the configured model in the watchdog
- use the same variable in `uninstall_jarvik.sh`

## Testing
- `bash -n watchdog.sh`
- `bash -n uninstall_jarvik.sh`


------
https://chatgpt.com/codex/tasks/task_b_685ae5f7a2608322a2481914cc2f9367