### PR TITLE
Support custom model via MODEL_NAME

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ jarvik-start
 
 ### Running with a different model
 
-All management scripts honour the `MODEL_NAME` environment variable. To start
-Jarvik with another model set the variable when invoking the script:
+All management scripts honour the `MODEL_NAME` environment variable. The Flask
+API will query whichever model is specified. To start Jarvik with another model
+set the variable when invoking the script:
 
 ```bash
 MODEL_NAME=mistral bash start.sh  # run with a different model
@@ -65,8 +66,8 @@ or via the alias:
 ```bash
 jarvik-status
 ```
-The script expects the Mistral model to be running persistently via
-`ollama run mistral`.
+The script expects the selected model to be running persistently via
+`ollama run $MODEL_NAME`.
 
 ## Stopping Jarvik and Uninstall
 

--- a/main.py
+++ b/main.py
@@ -3,6 +3,9 @@ from rag_engine import load_knowledge, search_knowledge
 import json
 import os
 
+# Allow custom model via environment variable
+MODEL_NAME = os.getenv("MODEL_NAME", "mistral")
+
 # Set base directory relative to this file
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 memory_path = os.path.join(BASE_DIR, "memory", "public.jsonl")
@@ -57,11 +60,10 @@ def ask():
 
     try:
         import requests
-        response = requests.post("http://localhost:11434/api/generate", json={
-            "model": "mistral",
-            "prompt": prompt,
-            "stream": False
-        })
+        response = requests.post(
+            "http://localhost:11434/api/generate",
+            json={"model": MODEL_NAME, "prompt": prompt, "stream": False}
+        )
         result = response.json()
         output = result.get("response", "").strip()
     except Exception as e:

--- a/manual
+++ b/manual
@@ -27,8 +27,10 @@ bash start.sh
 # nebo
 jarvik-start
 ```
-Skript aktivuje virtuální prostředí, spustí Ollamu, model Mistral a nakonec Flask server na portu 8010.
-Pokud model chybí, stáhne se automaticky.
+Skript aktivuje virtuální prostředí, spustí Ollamu, zvolený model (výchozí
+mistral) a nakonec Flask server na portu 8010. Pokud model chybí, stáhne se
+automaticky. Pro jiný model nastavte proměnnou `MODEL_NAME` při spuštění –
+stejnou hodnotu používá i samotná Flask aplikace.
 
 ## Stav běžících služeb
 

--- a/status.sh
+++ b/status.sh
@@ -4,6 +4,9 @@ GREEN='\033[1;32m'
 RED='\033[1;31m'
 NC='\033[0m'
 
+# Use custom model if provided
+MODEL_NAME=${MODEL_NAME:-mistral}
+
 echo "🔍 Kontrola systému JARVIK..."
 
 # Ollama
@@ -14,16 +17,16 @@ else
 fi
 
 # Mistral
-if pgrep -f "ollama run mistral" > /dev/null; then
-  echo -e "✅ Model Mistral běží"
+if pgrep -f "ollama run $MODEL_NAME" > /dev/null; then
+  echo -e "✅ Model $MODEL_NAME běží"
 else
-  echo -e "❌ Model Mistral NEběží"
+  echo -e "❌ Model $MODEL_NAME NEběží"
   if command -v ollama >/dev/null 2>&1; then
     # Pokud běží Ollama, ale proces Mistral chybí, zkus ověřit port 11434
     if ss -tuln 2>/dev/null | grep -q ":11434" || nc -z localhost 11434 >/dev/null 2>&1; then
-      echo "   Ollama běží, ale proces mistral nebyl nalezen."
+      echo "   Ollama běží, ale proces $MODEL_NAME nebyl nalezen."
     fi
-    echo "   Spusťte jej příkazem 'ollama run mistral &' nebo 'jarvik-start'."
+    echo "   Spusťte jej příkazem 'ollama run $MODEL_NAME &' nebo 'jarvik-start'."
   else
     echo "   Chybí program 'ollama'."
   fi


### PR DESCRIPTION
## Summary
- allow selecting model through `MODEL_NAME` in `status.sh`
- read `MODEL_NAME` in `main.py` and send it to Ollama
- document model variable use in the manual and README

## Testing
- `bash -n status.sh`
- `python3 -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_b_685b1438d5188322b0e97e613339f410