### PR TITLE
Update model name handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ bash start.sh
 ```
 
 The script checks for required commands and automatically downloads the
-`mistral` model if it is missing. Po spuštění vypíše, zda se všechny části
+selected model (defaults to `mistral`) if it is missing. Po spuštění vypíše,
+zda se všechny části
 správně nastartovaly, případné chyby hledejte v souborech `*.log`.
 With the aliases loaded you can simply type:
 
@@ -49,7 +50,7 @@ All management scripts honour the `MODEL_NAME` environment variable. To start
 Jarvik with another model set the variable when invoking the script:
 
 ```bash
-MODEL_NAME=mistral bash start.sh  # run with a different model
+MODEL_NAME=llama3 bash start.sh  # run with a different model
 ```
 
 ## Checking Status
@@ -65,8 +66,8 @@ or via the alias:
 ```bash
 jarvik-status
 ```
-The script expects the Mistral model to be running persistently via
-`ollama run mistral`.
+The script expects the chosen model to be running persistently via
+`ollama run $MODEL_NAME` (defaults to `mistral`).
 
 ## Stopping Jarvik and Uninstall
 
@@ -76,7 +77,7 @@ Jarvik can be stopped and fully removed using the uninstall script:
 bash uninstall_jarvik.sh
 ```
 
-The script stops Ollama, Mistral and Flask, removes the `venv/` and
+The script stops Ollama, the running model and Flask, removes the `venv/` and
 `memory/` directories and cleans the Jarvik aliases from `~/.bashrc`.
 
 ## Quick Start Script
@@ -108,7 +109,7 @@ restart missing processes automatically:
 bash watchdog.sh
 ```
 
-The watchdog checks every five seconds that Ollama, the Mistral model and
+The watchdog checks every five seconds that Ollama, the selected model and
 the Flask server are up and restarts them when needed.
 
 ## Upgrade

--- a/manual
+++ b/manual
@@ -27,8 +27,10 @@ bash start.sh
 # nebo
 jarvik-start
 ```
-Skript aktivuje virtuální prostředí, spustí Ollamu, model Mistral a nakonec Flask server na portu 8010.
+Skript aktivuje virtuální prostředí, spustí Ollamu, zvolený model (výchozí `mistral`) a nakonec Flask server na portu 8010.
 Pokud model chybí, stáhne se automaticky.
+Všechny skripty respektují proměnnou `MODEL_NAME`, kterou můžete nastavit na jiné
+označení modelu.
 
 ## Stav běžících služeb
 
@@ -46,7 +48,7 @@ Pro zastavení všech služeb a odstranění prostředí použijte:
 ```bash
 bash uninstall_jarvik.sh
 ```
-Skript ukončí Ollamu, Mistral i Flask, smaže adresáře `venv/` a `memory/` a vyčistí aliasy z `~/.bashrc`.
+Skript ukončí Ollamu, běžící model a Flask, smaže adresáře `venv/` a `memory/` a vyčistí aliasy z `~/.bashrc`.
 
 ## Rychlý start
 

--- a/run_jarvik.sh
+++ b/run_jarvik.sh
@@ -4,6 +4,8 @@ GREEN='\033[1;32m'
 RED='\033[1;31m'
 NC='\033[0m'
 
+MODEL_NAME=${MODEL_NAME:-mistral}
+
 cd "$(dirname "$0")" || exit
 
 # Aktivuj venv
@@ -41,22 +43,22 @@ if ! pgrep -f "ollama serve" > /dev/null; then
   fi
 fi
 
-# Zajistit stažení modelu mistral
-if ! ollama list 2>/dev/null | grep -q '^mistral'; then
-  echo -e "${GREEN}⬇️  Stahuji model mistral...${NC}"
-  if ! ollama pull mistral >> ollama.log 2>&1; then
+# Zajistit stažení modelu $MODEL_NAME
+if ! ollama list 2>/dev/null | grep -q "^$MODEL_NAME"; then
+  echo -e "${GREEN}⬇️  Stahuji model $MODEL_NAME...${NC}"
+  if ! ollama pull "$MODEL_NAME" >> ollama.log 2>&1; then
     echo -e "${RED}❌ Stažení modelu selhalo, zkontrolujte připojení${NC}"
     exit 1
   fi
 fi
 
-# Spustit model mistral, pokud neběží
-if ! pgrep -f "ollama run mistral" > /dev/null; then
-  echo -e "${GREEN}🧠 Spouštím model mistral...${NC}"
-  nohup ollama run mistral > mistral.log 2>&1 &
+# Spustit model $MODEL_NAME, pokud neběží
+if ! pgrep -f "ollama run $MODEL_NAME" > /dev/null; then
+  echo -e "${GREEN}🧠 Spouštím model $MODEL_NAME...${NC}"
+  nohup ollama run "$MODEL_NAME" > mistral.log 2>&1 &
   sleep 2
-  if ! pgrep -f "ollama run mistral" > /dev/null; then
-    echo -e "${RED}❌ Model mistral se nespustil, zkontrolujte mistral.log${NC}"
+  if ! pgrep -f "ollama run $MODEL_NAME" > /dev/null; then
+    echo -e "${RED}❌ Model $MODEL_NAME se nespustil, zkontrolujte mistral.log${NC}"
     exit 1
   fi
 fi

--- a/start.sh
+++ b/start.sh
@@ -3,6 +3,8 @@ GREEN="\033[1;32m"
 RED="\033[1;31m"
 NC="\033[0m"
 
+MODEL_NAME=${MODEL_NAME:-mistral}
+
 cd "$(dirname "$0")" || exit
 
 # Aktivovat venv, pokud ještě není aktivní
@@ -41,22 +43,22 @@ if ! pgrep -f "ollama serve" > /dev/null; then
   fi
 fi
 
-# Ověřit dostupnost modelu mistral a případně jej stáhnout
-if ! ollama list 2>/dev/null | grep -q '^mistral'; then
-  echo -e "${GREEN}⬇️  Stahuji model mistral...${NC}"
-  if ! ollama pull mistral >> ollama.log 2>&1; then
+# Ověřit dostupnost modelu $MODEL_NAME a případně jej stáhnout
+if ! ollama list 2>/dev/null | grep -q "^$MODEL_NAME"; then
+  echo -e "${GREEN}⬇️  Stahuji model $MODEL_NAME...${NC}"
+  if ! ollama pull "$MODEL_NAME" >> ollama.log 2>&1; then
     echo -e "${RED}❌ Stažení modelu selhalo, zkontrolujte připojení${NC}"
     exit 1
   fi
 fi
 
-# Spustit mistral, pokud neběží
-if ! pgrep -f "ollama run mistral" > /dev/null; then
-  echo -e "${GREEN}🧠 Spouštím model mistral...${NC}"
-  nohup ollama run mistral > mistral.log 2>&1 &
+# Spustit $MODEL_NAME, pokud neběží
+if ! pgrep -f "ollama run $MODEL_NAME" > /dev/null; then
+  echo -e "${GREEN}🧠 Spouštím model $MODEL_NAME...${NC}"
+  nohup ollama run "$MODEL_NAME" > mistral.log 2>&1 &
   sleep 2
-  if ! pgrep -f "ollama run mistral" > /dev/null; then
-    echo -e "${RED}❌ Model mistral se nespustil, zkontrolujte mistral.log${NC}"
+  if ! pgrep -f "ollama run $MODEL_NAME" > /dev/null; then
+    echo -e "${RED}❌ Model $MODEL_NAME se nespustil, zkontrolujte mistral.log${NC}"
     exit 1
   fi
 fi

--- a/uninstall_jarvik.sh
+++ b/uninstall_jarvik.sh
@@ -2,7 +2,7 @@
 DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$DIR" || exit
 set -e
-MODEL_NAME=${MODEL_NAME:-jarvik-mistral}
+MODEL_NAME=${MODEL_NAME:-mistral}
 
 echo "🗑️ Odinstalace Jarvika..."
 

--- a/watchdog.sh
+++ b/watchdog.sh
@@ -2,7 +2,7 @@
 GREEN="\033[1;32m"
 RED="\033[1;31m"
 NC="\033[0m"
-MODEL_NAME=${MODEL_NAME:-jarvik-mistral}
+MODEL_NAME=${MODEL_NAME:-mistral}
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$DIR" || exit


### PR DESCRIPTION
## Summary
- allow setting `MODEL_NAME` across startup scripts
- mention the variable in docs
- standardize defaults to `mistral`

## Testing
- `bash -n start.sh run_jarvik.sh watchdog.sh uninstall_jarvik.sh`

------
https://chatgpt.com/codex/tasks/task_b_685b0ff64b0c832283d88ae73850979a