### PR TITLE
Use variable for model log

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ bash monitor.sh
 ```
 
 The script refreshes every two seconds and shows the last lines from
-`flask.log`, `mistral.log` and `ollama.log` produced by `start.sh`.
+`flask.log`, `<model>.log` and `ollama.log` produced by `start.sh`.
 
 ## Automatic Restart
 

--- a/monitor.sh
+++ b/monitor.sh
@@ -5,6 +5,10 @@
 DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$DIR" || exit
 
+# Default model name if not provided
+MODEL_NAME=${MODEL_NAME:-mistral}
+MODEL_LOG="${MODEL_NAME}.log"
+
 while true; do
   clear
   echo "===== Stav Jarvika ====="
@@ -20,12 +24,12 @@ while true; do
     echo
   fi
 
-  if [ -f mistral.log ]; then
+  if [ -f "$MODEL_LOG" ]; then
     echo "--- Poslední logy Mistralu ---"
-    tail -n 5 mistral.log
-    echo
+    tail -n 5 "$MODEL_LOG"
+  echo
   else
-    echo "(Žádný mistral.log)"
+    echo "(Žádný $MODEL_LOG)"
     echo
   fi
 

--- a/run_jarvik.sh
+++ b/run_jarvik.sh
@@ -6,6 +6,11 @@ NC='\033[0m'
 
 cd "$(dirname "$0")" || exit
 
+# Default model name can be overridden via MODEL_NAME
+MODEL_NAME=${MODEL_NAME:-mistral}
+# Log file for the running model
+MODEL_LOG="${MODEL_NAME}.log"
+
 # Aktivuj venv
 if [[ -z "$VIRTUAL_ENV" ]]; then
   if [ -f venv/bin/activate ]; then
@@ -53,10 +58,10 @@ fi
 # Spustit model mistral, pokud neběží
 if ! pgrep -f "ollama run mistral" > /dev/null; then
   echo -e "${GREEN}🧠 Spouštím model mistral...${NC}"
-  nohup ollama run mistral > mistral.log 2>&1 &
+  nohup ollama run mistral > "$MODEL_LOG" 2>&1 &
   sleep 2
   if ! pgrep -f "ollama run mistral" > /dev/null; then
-    echo -e "${RED}❌ Model mistral se nespustil, zkontrolujte mistral.log${NC}"
+    echo -e "${RED}❌ Model mistral se nespustil, zkontrolujte $MODEL_LOG${NC}"
     exit 1
   fi
 fi

--- a/start.sh
+++ b/start.sh
@@ -5,6 +5,11 @@ NC="\033[0m"
 
 cd "$(dirname "$0")" || exit
 
+# Model name can be overridden with the MODEL_NAME environment variable
+MODEL_NAME=${MODEL_NAME:-mistral}
+# Log file for the model output
+MODEL_LOG="${MODEL_NAME}.log"
+
 # Aktivovat venv, pokud ještě není aktivní
 if [ -z "$VIRTUAL_ENV" ]; then
   if [ -f venv/bin/activate ]; then
@@ -53,10 +58,10 @@ fi
 # Spustit mistral, pokud neběží
 if ! pgrep -f "ollama run mistral" > /dev/null; then
   echo -e "${GREEN}🧠 Spouštím model mistral...${NC}"
-  nohup ollama run mistral > mistral.log 2>&1 &
+  nohup ollama run mistral > "$MODEL_LOG" 2>&1 &
   sleep 2
   if ! pgrep -f "ollama run mistral" > /dev/null; then
-    echo -e "${RED}❌ Model mistral se nespustil, zkontrolujte mistral.log${NC}"
+    echo -e "${RED}❌ Model mistral se nespustil, zkontrolujte $MODEL_LOG${NC}"
     exit 1
   fi
 fi

--- a/watchdog.sh
+++ b/watchdog.sh
@@ -3,6 +3,7 @@ GREEN="\033[1;32m"
 RED="\033[1;31m"
 NC="\033[0m"
 MODEL_NAME=${MODEL_NAME:-jarvik-mistral}
+MODEL_LOG="${MODEL_NAME}.log"
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$DIR" || exit
@@ -24,7 +25,7 @@ check_ollama() {
 check_mistral() {
   if ! pgrep -f "ollama run $MODEL_NAME" > /dev/null; then
     echo -e "${RED}⚠️  Model $MODEL_NAME neběží. Restartuji...${NC}"
-    nohup ollama run "$MODEL_NAME" >> mistral.log 2>&1 &
+    nohup ollama run "$MODEL_NAME" >> "$MODEL_LOG" 2>&1 &
   fi
 }
 


### PR DESCRIPTION
## Summary
- add `MODEL_LOG` variable for the model's log file
- replace hardcoded `mistral.log` with `$MODEL_LOG`
- document `<model>.log` in README

## Testing
- `bash status.sh > /tmp/status_output.txt && tail -n 5 /tmp/status_output.txt`

------
https://chatgpt.com/codex/tasks/task_b_685b183ed2708322a4b7ed877d9c194c