### PR TITLE
Update docs for MODEL_NAME support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ bash start.sh
 ```
 
 The script checks for required commands and automatically downloads the
-`mistral` model if it is missing. Po spuštění vypíše, zda se všechny části
-správně nastartovaly, případné chyby hledejte v souborech `*.log`.
+model specified in `MODEL_NAME` (defaults to `mistral`) if it is missing.
+Po spuštění vypíše, zda se všechny části správně nastartovaly, případné
+chyby hledejte v souborech `*.log`.
 With the aliases loaded you can simply type:
 
 ```bash
@@ -50,8 +51,10 @@ API will query whichever model is specified. To start Jarvik with another model
 set the variable when invoking the script:
 
 ```bash
-MODEL_NAME=mistral bash start.sh  # run with a different model
+MODEL_NAME="mistral:7b-Q4_K_M" bash start.sh  # run with a different model
 ```
+
+All provided scripts now fully honour this variable.
 
 ## Checking Status
 

--- a/manual
+++ b/manual
@@ -28,9 +28,13 @@ bash start.sh
 jarvik-start
 ```
 Skript aktivuje virtuální prostředí, spustí Ollamu, zvolený model (výchozí
-mistral) a nakonec Flask server na portu 8010. Pokud model chybí, stáhne se
+`mistral`) a nakonec Flask server na portu 8010. Pokud model chybí, stáhne se
 automaticky. Pro jiný model nastavte proměnnou `MODEL_NAME` při spuštění –
-stejnou hodnotu používá i samotná Flask aplikace.
+stejnou hodnotu používá i samotná Flask aplikace. Například:
+```bash
+MODEL_NAME="mistral:7b-Q4_K_M" bash start.sh
+```
+Všechny přiložené skripty nyní tuto proměnnou plně respektují.
 
 ## Stav běžících služeb
 

--- a/run_jarvik.sh
+++ b/run_jarvik.sh
@@ -46,22 +46,22 @@ if ! pgrep -f "ollama serve" > /dev/null; then
   fi
 fi
 
-# Zajistit stažení modelu mistral
-if ! ollama list 2>/dev/null | grep -q '^mistral'; then
-  echo -e "${GREEN}⬇️  Stahuji model mistral...${NC}"
-  if ! ollama pull mistral >> ollama.log 2>&1; then
+# Zajistit stažení zvoleného modelu
+if ! ollama list 2>/dev/null | grep -q "^$MODEL_NAME"; then
+  echo -e "${GREEN}⬇️  Stahuji model $MODEL_NAME...${NC}"
+  if ! ollama pull "$MODEL_NAME" >> ollama.log 2>&1; then
     echo -e "${RED}❌ Stažení modelu selhalo, zkontrolujte připojení${NC}"
     exit 1
   fi
 fi
 
-# Spustit model mistral, pokud neběží
-if ! pgrep -f "ollama run mistral" > /dev/null; then
-  echo -e "${GREEN}🧠 Spouštím model mistral...${NC}"
-  nohup ollama run mistral > "$MODEL_LOG" 2>&1 &
+# Spustit model, pokud neběží
+if ! pgrep -f "ollama run $MODEL_NAME" > /dev/null; then
+  echo -e "${GREEN}🧠 Spouštím model $MODEL_NAME...${NC}"
+  nohup ollama run "$MODEL_NAME" > "$MODEL_LOG" 2>&1 &
   sleep 2
-  if ! pgrep -f "ollama run mistral" > /dev/null; then
-    echo -e "${RED}❌ Model mistral se nespustil, zkontrolujte $MODEL_LOG${NC}"
+  if ! pgrep -f "ollama run $MODEL_NAME" > /dev/null; then
+    echo -e "${RED}❌ Model $MODEL_NAME se nespustil, zkontrolujte $MODEL_LOG${NC}"
     exit 1
   fi
 fi

--- a/start.sh
+++ b/start.sh
@@ -46,22 +46,22 @@ if ! pgrep -f "ollama serve" > /dev/null; then
   fi
 fi
 
-# Ověřit dostupnost modelu mistral a případně jej stáhnout
-if ! ollama list 2>/dev/null | grep -q '^mistral'; then
-  echo -e "${GREEN}⬇️  Stahuji model mistral...${NC}"
-  if ! ollama pull mistral >> ollama.log 2>&1; then
+# Ověřit dostupnost vybraného modelu a případně jej stáhnout
+if ! ollama list 2>/dev/null | grep -q "^$MODEL_NAME"; then
+  echo -e "${GREEN}⬇️  Stahuji model $MODEL_NAME...${NC}"
+  if ! ollama pull "$MODEL_NAME" >> ollama.log 2>&1; then
     echo -e "${RED}❌ Stažení modelu selhalo, zkontrolujte připojení${NC}"
     exit 1
   fi
 fi
 
-# Spustit mistral, pokud neběží
-if ! pgrep -f "ollama run mistral" > /dev/null; then
-  echo -e "${GREEN}🧠 Spouštím model mistral...${NC}"
-  nohup ollama run mistral > "$MODEL_LOG" 2>&1 &
+# Spustit model, pokud neběží
+if ! pgrep -f "ollama run $MODEL_NAME" > /dev/null; then
+  echo -e "${GREEN}🧠 Spouštím model $MODEL_NAME...${NC}"
+  nohup ollama run "$MODEL_NAME" > "$MODEL_LOG" 2>&1 &
   sleep 2
-  if ! pgrep -f "ollama run mistral" > /dev/null; then
-    echo -e "${RED}❌ Model mistral se nespustil, zkontrolujte $MODEL_LOG${NC}"
+  if ! pgrep -f "ollama run $MODEL_NAME" > /dev/null; then
+    echo -e "${RED}❌ Model $MODEL_NAME se nespustil, zkontrolujte $MODEL_LOG${NC}"
     exit 1
   fi
 fi


### PR DESCRIPTION
## Summary
- clarify that start scripts will download the model specified by `MODEL_NAME`
- show how to launch Jarvik with any model
- mention that all scripts honor `MODEL_NAME`
- update Czech manual with the same instructions
- fully support `MODEL_NAME` in `start.sh` and `run_jarvik.sh`

## Testing
- `bash -n start.sh run_jarvik.sh watchdog.sh status.sh monitor.sh uninstall_jarvik.sh install_jarvik.sh upgrade.sh update.sh load.sh activate.sh`

------
https://chatgpt.com/codex/tasks/task_b_685b261eee6883229c86481cd6b4632b