### PR TITLE
Add start_model script and alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ After installation, add handy shell aliases by executing `load.sh`:
 bash load.sh
 ```
 
-This will append alias commands such as `jarvik-start` and `jarvik-status`
-to your `~/.bashrc` and reload the file.
+This will append alias commands such as `jarvik-start`, `jarvik-status` and
+`jarvik-model` to your `~/.bashrc` and reload the file.
 
 ## Starting Jarvik
 
@@ -51,6 +51,20 @@ set the variable when invoking the script:
 
 ```bash
 MODEL_NAME=mistral bash start.sh  # run with a different model
+```
+
+### Starting only the model
+
+When you just need the model running without Flask, use:
+
+```bash
+bash start_model.sh
+```
+
+With aliases loaded this is simply:
+
+```bash
+jarvik-model
 ```
 
 ## Checking Status

--- a/load.sh
+++ b/load.sh
@@ -10,6 +10,7 @@ alias jarvik-start='bash $DIR/start.sh'
 alias jarvik-status='bash $DIR/status.sh'
 alias jarvik-install='bash $DIR/install_jarvik.sh'
 alias jarvik-flask='source $DIR/venv/bin/activate && python $DIR/main.py'
+alias jarvik-model='bash $DIR/start_model.sh'
 
 EOF
 fi

--- a/manual
+++ b/manual
@@ -17,7 +17,8 @@ Tento krátký manuál popisuje základní kroky pro instalaci a spuštění Jar
    ```bash
    bash load.sh
    ```
-   Do souboru `~/.bashrc` se přidají příkazy jako `jarvik-start` či `jarvik-status`.
+   Do souboru `~/.bashrc` se přidají příkazy jako `jarvik-start`, `jarvik-status`
+   a `jarvik-model`.
 
 ## Spuštění
 
@@ -31,6 +32,20 @@ Skript aktivuje virtuální prostředí, spustí Ollamu, zvolený model (výchoz
 mistral) a nakonec Flask server na portu 8010. Pokud model chybí, stáhne se
 automaticky. Pro jiný model nastavte proměnnou `MODEL_NAME` při spuštění –
 stejnou hodnotu používá i samotná Flask aplikace.
+
+### Spuštění pouze modelu
+
+Pokud potřebujete jen běžící model bez Flasku, spusťte:
+
+```bash
+bash start_model.sh
+```
+
+Po načtení aliasů stačí příkaz:
+
+```bash
+jarvik-model
+```
 
 ## Stav běžících služeb
 

--- a/start_model.sh
+++ b/start_model.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+GREEN='\033[1;32m'
+RED='\033[1;31m'
+NC='\033[0m'
+
+cd "$(dirname "$0")" || exit
+
+# Default model name can be overridden via MODEL_NAME
+MODEL_NAME=${MODEL_NAME:-mistral}
+MODEL_LOG="${MODEL_NAME}.log"
+
+# Ensure ollama is available
+if ! command -v ollama >/dev/null 2>&1; then
+  echo -e "${RED}❌ Chybí program 'ollama'. Nainstalujte jej a spusťte znovu.${NC}"
+  exit 1
+fi
+
+# Start Ollama if not running
+if ! pgrep -f "ollama serve" > /dev/null; then
+  echo -e "${GREEN}🚀 Spouštím Ollama...${NC}"
+  nohup ollama serve > ollama.log 2>&1 &
+  for i in {1..10}; do
+    if curl -s http://localhost:11434/api/tags >/dev/null 2>&1; then
+      break
+    fi
+    sleep 1
+  done
+  if ! curl -s http://localhost:11434/api/tags >/dev/null 2>&1; then
+    echo -e "${RED}❌ Ollama se nespustila, zkontrolujte ollama.log${NC}"
+    exit 1
+  fi
+fi
+
+# Pull the requested model if missing
+if ! ollama list 2>/dev/null | grep -q "^$MODEL_NAME"; then
+  echo -e "${GREEN}⬇️  Stahuji model $MODEL_NAME...${NC}"
+  if ! ollama pull "$MODEL_NAME" >> ollama.log 2>&1; then
+    echo -e "${RED}❌ Stažení modelu selhalo, zkontrolujte připojení${NC}"
+    exit 1
+  fi
+fi
+
+# Start the model
+if ! pgrep -f "ollama run $MODEL_NAME" > /dev/null; then
+  echo -e "${GREEN}🧠 Spouštím model $MODEL_NAME...${NC}"
+  nohup ollama run "$MODEL_NAME" > "$MODEL_LOG" 2>&1 &
+  sleep 2
+  if ! pgrep -f "ollama run $MODEL_NAME" > /dev/null; then
+    echo -e "${RED}❌ Model $MODEL_NAME se nespustil, zkontrolujte $MODEL_LOG${NC}"
+    exit 1
+  fi
+else
+  echo -e "${GREEN}✅ Model $MODEL_NAME již běží${NC}"
+fi


### PR DESCRIPTION
## Summary
- add new `start_model.sh` to launch a single Ollama model
- expose script via `jarvik-model` alias in `load.sh`
- document new script and alias in the README and Czech manual

## Testing
- `bash -n start_model.sh`
- `bash -n load.sh`

------
https://chatgpt.com/codex/tasks/task_b_685b26201e14832286e20a09c0fd465d