### PR TITLE
Unify default model

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Jarvik
 
-This repository contains scripts to run the Jarvik assistant locally.
+This repository contains scripts to run the Jarvik assistant locally. By default
+all helper scripts use the `mistral` model from Ollama, but you can override the
+model by setting the `MODEL_NAME` environment variable.
 
 ## Installation
 

--- a/manual
+++ b/manual
@@ -2,6 +2,8 @@
 
 Tento krátký manuál popisuje základní kroky pro instalaci a spuštění Jarvika na lokálním stroji.
 
+Ve výchozím nastavení používají skripty model `mistral`. Pokud chcete používat jiný model, nastavte proměnnou `MODEL_NAME` při jejich spouštění.
+
 ## Instalace
 
 1. Spusťte instalační skript, který vytvoří virtuální prostředí a nainstaluje závislosti:

--- a/uninstall_jarvik.sh
+++ b/uninstall_jarvik.sh
@@ -2,7 +2,7 @@
 DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$DIR" || exit
 set -e
-MODEL_NAME=${MODEL_NAME:-jarvik-mistral}
+MODEL_NAME=${MODEL_NAME:-mistral}
 
 echo "🗑️ Odinstalace Jarvika..."
 

--- a/watchdog.sh
+++ b/watchdog.sh
@@ -2,7 +2,7 @@
 GREEN="\033[1;32m"
 RED="\033[1;31m"
 NC="\033[0m"
-MODEL_NAME=${MODEL_NAME:-jarvik-mistral}
+MODEL_NAME=${MODEL_NAME:-mistral}
 MODEL_LOG="${MODEL_NAME}.log"
 
 DIR="$(cd "$(dirname "$0")" && pwd)"


### PR DESCRIPTION
## Summary
- default to `mistral` in the watchdog and uninstall scripts
- document the `mistral` default in README and manual

## Testing
- `bash -n uninstall_jarvik.sh watchdog.sh`

------
https://chatgpt.com/codex/tasks/task_b_685b2620ba8883229daba90557bd8a3b