### PR TITLE
Set default model to mistral

### DIFF
--- a/uninstall_jarvik.sh
+++ b/uninstall_jarvik.sh
@@ -2,7 +2,7 @@
 DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$DIR" || exit
 set -e
-MODEL_NAME=${MODEL_NAME:-jarvik-mistral}
+MODEL_NAME=${MODEL_NAME:-mistral}
 
 echo "🗑️ Odinstalace Jarvika..."
 

--- a/watchdog.sh
+++ b/watchdog.sh
@@ -2,7 +2,7 @@
 GREEN="\033[1;32m"
 RED="\033[1;31m"
 NC="\033[0m"
-MODEL_NAME=${MODEL_NAME:-jarvik-mistral}
+MODEL_NAME=${MODEL_NAME:-mistral}
 MODEL_LOG="${MODEL_NAME}.log"
 
 DIR="$(cd "$(dirname "$0")" && pwd)"


### PR DESCRIPTION
## Summary
- update uninstall_jarvik.sh and watchdog.sh to default to `mistral`
- keep documentation accurate about the default model
- verify all shell scripts pass `bash -n`

## Testing
- `bash -n activate.sh install_jarvik.sh load.sh monitor.sh run_jarvik.sh start.sh status.sh uninstall_jarvik.sh update.sh watchdog.sh upgrade.sh`

------
https://chatgpt.com/codex/tasks/task_b_685b2d43941483228ddb90edbe7f960c