### PR TITLE
Add port utility checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Install dependencies and create the virtual environment:
 bash install_jarvik.sh
 ```
 
+Make sure the commands `ollama`, `curl`, `lsof` and either `ss` (from
+`iproute2`) or `nc` (from `netcat`) are available on your system.
+
 If you need a fresh start, run the installer with `--clean` to first remove
 any previous environment:
 

--- a/run_jarvik.sh
+++ b/run_jarvik.sh
@@ -23,7 +23,7 @@ if [[ -z "$VIRTUAL_ENV" ]]; then
 fi
 
 # Kontrola potřebných příkazů
-for cmd in ollama python3 curl; do
+for cmd in ollama python3 curl lsof; do
   if ! command -v "$cmd" >/dev/null 2>&1; then
     echo -e "${RED}❌ Chybí příkaz $cmd. Nainstalujte jej a spusťte znovu.${NC}"
     exit 1

--- a/start.sh
+++ b/start.sh
@@ -29,6 +29,12 @@ for cmd in ollama python3 curl; do
   fi
 done
 
+# Potřebujeme také 'ss' nebo 'nc' pro kontrolu běžících portů
+if ! command -v ss >/dev/null 2>&1 && ! command -v nc >/dev/null 2>&1; then
+  echo -e "${RED}❌ Chybí příkazy 'ss' i 'nc'. Nainstalujte balíček iproute2 nebo netcat.${NC}"
+  exit 1
+fi
+
 # Spustit Ollama, pokud neběží
 if ! pgrep -f "ollama serve" > /dev/null; then
   echo -e "${GREEN}🚀 Spouštím Ollama...${NC}"


### PR DESCRIPTION
## Summary
- check for `ss` or `nc` presence when starting Jarvik
- check `lsof` along with existing deps when using the quick start script
- document new dependency requirements

## Testing
- `bash -n activate.sh`
- `bash -n install_jarvik.sh`
- `bash -n load.sh`
- `bash -n monitor.sh`
- `bash -n run_jarvik.sh`
- `bash -n start.sh`
- `bash -n start_model.sh`
- `bash -n status.sh`
- `bash -n uninstall_jarvik.sh`
- `bash -n update.sh`
- `bash -n upgrade.sh`
- `bash -n watchdog.sh`


------
https://chatgpt.com/codex/tasks/task_b_685b2e41950c8322a1cd023db60130f1