### PR TITLE
Update start script names in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This will append alias commands such as `jarvik-start`, `jarvik-status` and
 To launch all components run:
 
 ```bash
-bash start.sh
+bash start_jarvik_mistral.sh
 ```
 
 The script checks for required commands and automatically downloads the
@@ -55,7 +55,14 @@ The Flask API will query whichever model is specified. To start Jarvik with any
 model simply set the variable when invoking the script. For example:
 
 ```bash
-MODEL_NAME="mistral:7b-Q4_K_M" bash start.sh
+MODEL_NAME="mistral:7b-Q4_K_M" bash start_jarvik_mistral.sh
+```
+Alternatively you can run the dedicated wrapper script:
+
+```bash
+bash start_Mistral_7B.sh
+# or using the alias
+jarvik-start-7b
 ```
 
 ### Starting only the model
@@ -102,10 +109,10 @@ The script stops Ollama, Mistral and Flask, removes the `venv/` and
 ## Quick Start Script
 
 For a single command that activates the environment, loads the model and
-starts Flask you can also use:
+starts Flask you can also use the main start script:
 
 ```bash
-bash run_jarvik.sh
+bash start_jarvik_mistral.sh
 ```
 
 ## Real-time Monitoring
@@ -117,7 +124,7 @@ bash monitor.sh
 ```
 
 The script refreshes every two seconds and shows the last lines from
-`flask.log`, `<model>.log` and `ollama.log` produced by `start.sh`.
+`flask.log`, `<model>.log` and `ollama.log` produced by `start_jarvik_mistral.sh`.
 
 ## Automatic Restart
 

--- a/manual
+++ b/manual
@@ -24,9 +24,9 @@ Ve výchozím nastavení používají skripty model `mistral`. Pokud chcete pou�
 
 ## Spuštění
 
-Jarvika spustíte buď přímo pomocí skriptu `start.sh`, nebo přes alias `jarvik-start` (pokud jste provedli krok s načtením aliasů):
+Jarvika spustíte buď přímo pomocí skriptu `start_jarvik_mistral.sh`, nebo přes alias `jarvik-start` (pokud jste provedli krok s načtením aliasů):
 ```bash
-bash start.sh
+bash start_jarvik_mistral.sh
 # nebo
 jarvik-start
 ```
@@ -36,7 +36,14 @@ automaticky. Pro jiný model nastavte proměnnou `MODEL_NAME` při spuštění �
 všechny dodané skripty ji nyní plně respektují. Například:
 
 ```bash
-MODEL_NAME="mistral:7b-Q4_K_M" bash start.sh
+MODEL_NAME="mistral:7b-Q4_K_M" bash start_jarvik_mistral.sh
+```
+nebo použijte připravený skript pro Mistral 7B:
+
+```bash
+bash start_Mistral_7B.sh
+# nebo
+jarvik-start-7b
 ```
 Stejnou hodnotu používá i samotná Flask aplikace.
 
@@ -74,9 +81,9 @@ Skript ukončí Ollamu, Mistral i Flask, smaže adresáře `venv/` a `memory/` a
 
 ## Rychlý start
 
-Pro jednorázové spuštění všech komponent slouží skript `run_jarvik.sh`, který aktivuje prostředí, spustí model i server v jednom kroku:
+Pro jednorázové spuštění všech komponent slouží skript `start_jarvik_mistral.sh`, který aktivuje prostředí, spustí model i server v jednom kroku:
 ```bash
-bash run_jarvik.sh
+bash start_jarvik_mistral.sh
 ```
 
 ## Upgrade


### PR DESCRIPTION
## Summary
- update README and manual to use `start_jarvik_mistral.sh`
- show example with `start_Mistral_7B.sh`
- remove outdated `run_jarvik.sh` references

## Testing
- `bash -n start_jarvik_mistral.sh start_Mistral_7B.sh start_model.sh`

------
https://chatgpt.com/codex/tasks/task_b_685b998e7118832284cfdbad814f5c71