### PR TITLE
Remove update.sh references

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ the Flask server are up and restarts them when needed.
 To download the latest version, reinstall and start Jarvik automatically run:
 
 ```bash
-bash upgrade.sh  # nebo update.sh
+bash upgrade.sh
 ```
 
 The script pulls the newest repository files, performs an uninstall, installs the dependencies again, reloads the shell aliases and starts all components.

--- a/manual
+++ b/manual
@@ -88,8 +88,8 @@ bash start_jarvik_mistral.sh
 
 ## Upgrade
 
-Nejnovější verzi můžete stáhnout a nainstalovat skriptem `upgrade.sh` (alias `update.sh`):
+Nejnovější verzi můžete stáhnout a nainstalovat skriptem `upgrade.sh`:
 ```bash
-bash upgrade.sh  # nebo update.sh
+bash upgrade.sh
 ```
 Skript stáhne nové soubory z repozitáře, provede odinstalování, znovu nainstaluje závislosti, obnoví aliasy v `~/.bashrc` a spustí Jarvika.

--- a/update.sh
+++ b/update.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-DIR="$(cd "$(dirname "$0")" && pwd)"
-bash "$DIR/upgrade.sh" "$@"


### PR DESCRIPTION
## Summary
- delete the obsolete `update.sh` wrapper script
- refer only to `upgrade.sh` in README and manual

## Testing
- `python3 -m py_compile main.py rag_engine.py`

------
https://chatgpt.com/codex/tasks/task_b_685b9e581c948322b8a1eba708f2edb8