### PR TITLE
Improve model process matching

### DIFF
--- a/start_jarvik_mistral.sh
+++ b/start_jarvik_mistral.sh
@@ -62,11 +62,11 @@ if ! ollama list 2>/dev/null | grep -q "^${MODEL_NAME}"; then
 fi
 
 # Spustit $MODEL_NAME, pokud neběží
-if ! pgrep -f "ollama run $MODEL_NAME" > /dev/null; then
+if ! pgrep -f -x "ollama run $MODEL_NAME" > /dev/null; then
   echo -e "${GREEN}🧠 Spouštím model $MODEL_NAME...${NC}"
   nohup ollama run "$MODEL_NAME" > "$MODEL_LOG" 2>&1 &
   sleep 2
-  if ! pgrep -f "ollama run $MODEL_NAME" > /dev/null; then
+  if ! pgrep -f -x "ollama run $MODEL_NAME" > /dev/null; then
     echo -e "${RED}❌ Model $MODEL_NAME se nespustil, zkontrolujte $MODEL_LOG${NC}"
     exit 1
   fi

--- a/start_model.sh
+++ b/start_model.sh
@@ -41,11 +41,11 @@ if ! ollama list 2>/dev/null | grep -q "^$MODEL_NAME"; then
 fi
 
 # Start the model
-if ! pgrep -f "ollama run $MODEL_NAME" > /dev/null; then
+if ! pgrep -f -x "ollama run $MODEL_NAME" > /dev/null; then
   echo -e "${GREEN}🧠 Spouštím model $MODEL_NAME...${NC}"
   nohup ollama run "$MODEL_NAME" > "$MODEL_LOG" 2>&1 &
   sleep 2
-  if ! pgrep -f "ollama run $MODEL_NAME" > /dev/null; then
+  if ! pgrep -f -x "ollama run $MODEL_NAME" > /dev/null; then
     echo -e "${RED}❌ Model $MODEL_NAME se nespustil, zkontrolujte $MODEL_LOG${NC}"
     exit 1
   fi

--- a/status.sh
+++ b/status.sh
@@ -17,7 +17,7 @@ else
 fi
 
 # Model process
-if pgrep -f "ollama run $MODEL_NAME" > /dev/null; then
+if pgrep -f -x "ollama run $MODEL_NAME" > /dev/null; then
   echo -e "✅ Model $MODEL_NAME běží"
 else
   echo -e "❌ Model $MODEL_NAME NEběží"

--- a/watchdog.sh
+++ b/watchdog.sh
@@ -31,7 +31,7 @@ check_ollama() {
 }
 
 check_mistral() {
-  if ! pgrep -f "ollama run $MODEL_NAME" > /dev/null; then
+  if ! pgrep -f -x "ollama run $MODEL_NAME" > /dev/null; then
     echo -e "${RED}⚠️  Model $MODEL_NAME neběží. Restartuji...${NC}"
     nohup ollama run "$MODEL_NAME" >> "$MODEL_LOG" 2>&1 &
   fi


### PR DESCRIPTION
## Summary
- ensure model status checks match the exact command line
- update start scripts and watchdog accordingly

## Testing
- `python3 -m py_compile main.py rag_engine.py`
- `pgrep -f -x "ollama run $MODEL_NAME"` with a custom model name

------
https://chatgpt.com/codex/tasks/task_b_685ba37aedd48322b3882870025bd32b