### PR TITLE
Implement memory truncation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 This repository contains scripts to run the Jarvik assistant locally. By default
 all helper scripts use the `mistral` model from Ollama, but you can override the
 model by setting the `MODEL_NAME` environment variable.
+Jarvik keeps the entire conversation history unless you set the
+`MAX_MEMORY_ENTRIES` environment variable to limit how many exchanges are stored.
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- add configurable memory size and truncation logic
- keep only the latest 500 entries in `memory/public.jsonl`
- ensure `load_memory` only reads the recent entries

## Testing
- `python -m py_compile main.py rag_engine.py`

------
https://chatgpt.com/codex/tasks/task_b_685ba4ab96608322a4a4100d3f105a0f