### PR TITLE
Add script for running Flask separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,12 @@ jarvik-model
 
 ### Starting only the Flask server
 
-When the model is already running you can launch just the Flask API:
+When the model is already running you can launch just the Flask API using the
+new helper script or manually:
 
 ```bash
+bash start_flask.sh
+# or manually
 source venv/bin/activate && python main.py
 # or using the alias
 jarvik-flask

--- a/load.sh
+++ b/load.sh
@@ -10,7 +10,7 @@ alias jarvik-start='bash $DIR/start_jarvik_mistral.sh'
 alias jarvik-start-7b='bash $DIR/start_Mistral_7B.sh'
 alias jarvik-status='bash $DIR/status.sh'
 alias jarvik-install='bash $DIR/install_jarvik.sh'
-alias jarvik-flask='source $DIR/venv/bin/activate && python $DIR/main.py'
+alias jarvik-flask='bash $DIR/start_flask.sh'
 alias jarvik-model='bash $DIR/start_model.sh'
 alias jarvik-ollama='bash $DIR/start_ollama.sh'
 

--- a/manual
+++ b/manual
@@ -77,9 +77,12 @@ jarvik-model
 
 ### Spuštění pouze Flasku
 
-Pokud už máte spuštěný model a potřebujete jen Flask server, spusťte:
+Pokud už máte spuštěný model a potřebujete jen Flask server, spusťte nový
+skript nebo příkaz ručně:
 
 ```bash
+bash start_flask.sh
+# nebo ručně
 source venv/bin/activate && python main.py
 ```
 

--- a/start_flask.sh
+++ b/start_flask.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+GREEN='\033[1;32m'
+RED='\033[1;31m'
+NC='\033[0m'
+
+cd "$(dirname "$0")" || exit
+
+# Activate virtual environment
+if [ -f venv/bin/activate ]; then
+  source venv/bin/activate
+  echo -e "${GREEN}✅ Aktivováno virtuální prostředí${NC}"
+else
+  echo -e "${RED}❌ Chybí virtuální prostředí venv/. Spusťte install_jarvik.sh.${NC}"
+  exit 1
+fi
+
+# Start Flask server
+echo -e "${GREEN}🌐 Spouštím Flask server...${NC}"
+nohup python3 main.py > flask.log 2>&1 &
+sleep 2
+
+# Verify port 8010 is listening
+if command -v ss >/dev/null 2>&1; then
+  ss -tuln | grep -q ":8010"
+  running=$?
+elif command -v nc >/dev/null 2>&1; then
+  nc -z localhost 8010 >/dev/null 2>&1
+  running=$?
+else
+  running=1
+fi
+
+if [ "$running" = 0 ]; then
+  echo -e "${GREEN}✅ Flask běží na http://localhost:8010${NC}"
+else
+  echo -e "${RED}❌ Flask se nespustil, zkontrolujte flask.log${NC}"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add `start_flask.sh` to run the Flask API only
- hook the new script into alias setup
- document the script in README and manual

## Testing
- `bash -n start_flask.sh`

------
https://chatgpt.com/codex/tasks/task_b_685bb0f01b5c8322b561b22fab369bc6