### PR TITLE
Add offline model registration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,19 @@ bash start_Mistral_7B.sh
 jarvik-start-7b
 ```
 
+### Offline usage
+
+If you need to run without internet access, first download the model file (for
+example using `stahni-mistral-q4.sh`). Create a `Modelfile` that references the
+downloaded `.gguf` file and register it with:
+
+```bash
+ollama create mistral:7b-Q4_K_M -f Modelfile
+```
+
+When you set `LOCAL_MODEL_FILE` to the path of your local model, the start
+scripts will create the Ollama model automatically.
+
 ### Starting only Ollama
 
 When you want just the Ollama service without loading a model, run:

--- a/manual
+++ b/manual
@@ -47,6 +47,19 @@ jarvik-start-7b
 ```
 Stejnou hodnotu používá i samotná Flask aplikace.
 
+### Offline použití
+
+Pokud nemáte k dispozici internetové připojení, stáhněte si nejprve soubor s
+modelem, například skriptem `stahni-mistral-q4.sh`. Vytvořte `Modelfile` s řádkem
+`FROM /cesta/k/mistral.q4_K_M.gguf` a zaregistrujte model příkazem:
+
+```bash
+ollama create mistral:7b-Q4_K_M -f Modelfile
+```
+
+Nastavíte-li proměnnou `LOCAL_MODEL_FILE` na cestu k tomuto souboru, startovací
+skripty registraci provedou automaticky.
+
 ### Spuštění pouze Ollamy
 
 Pokud potřebujete spustit jen službu Ollama bez načtení modelu, použijte:


### PR DESCRIPTION
## Summary
- explain how to register a downloaded model in README
- add Czech offline instructions to the manual

## Testing
- `python3 -m py_compile main.py rag_engine.py`
- `bash -n start_model.sh start_jarvik_mistral.sh start_flask.sh start_ollama.sh start_Mistral_7B.sh`


------
https://chatgpt.com/codex/tasks/task_b_685bdcf3c9a4832289caac3728a53132