### PR TITLE
docs: clarify alias for Mistral 7B

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ bash load.sh
 ```
 
 This will append alias commands such as `jarvik-start`, `jarvik-status`,
-`jarvik-model`, `jarvik-flask` and `jarvik-ollama` to your `~/.bashrc` and reload the file.
+`jarvik-model`, `jarvik-flask`, `jarvik-ollama` and `jarvik-start-7b` to your
+`~/.bashrc` and reload the file.
 
 ## Starting Jarvik
 
@@ -65,6 +66,7 @@ Alternatively you can run the dedicated wrapper script:
 bash start_Mistral_7B.sh
 # or using the alias
 jarvik-start-7b
+# (available after running `bash load.sh`)
 ```
 
 ### Offline usage

--- a/manual
+++ b/manual
@@ -19,8 +19,8 @@ Ve výchozím nastavení používají skripty model `mistral`. Pokud chcete pou�
    ```bash
    bash load.sh
    ```
-   Do souboru `~/.bashrc` se přidají příkazy jako `jarvik-start`, `jarvik-status`,
-   `jarvik-model`, `jarvik-flask` a `jarvik-ollama`.
+    Do souboru `~/.bashrc` se přidají příkazy jako `jarvik-start`, `jarvik-status`,
+    `jarvik-model`, `jarvik-flask`, `jarvik-ollama` a `jarvik-start-7b`.
 
 ## Spuštění
 
@@ -44,6 +44,7 @@ nebo použijte připravený skript pro Mistral 7B:
 bash start_Mistral_7B.sh
 # nebo
 jarvik-start-7b
+# (k dispozici po spuštění `bash load.sh`)
 ```
 Stejnou hodnotu používá i samotná Flask aplikace.
 


### PR DESCRIPTION
## Summary
- document `jarvik-start-7b` alias in the README alias list
- mention the alias requires running `bash load.sh`
- update manual with the same information

## Testing
- `python -m py_compile main.py rag_engine.py`


------
https://chatgpt.com/codex/tasks/task_b_685be07f289c8322a638b1d41d6deda8