### PR TITLE
Add Q4 start wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ bash load.sh
 ```
 
 This will append alias commands such as `jarvik-start`, `jarvik-status`,
-`jarvik-model`, `jarvik-flask`, `jarvik-ollama` and `jarvik-start-7b` to your
-`~/.bashrc` and reload the file.
+`jarvik-model`, `jarvik-flask`, `jarvik-ollama`, `jarvik-start-7b` and
+`jarvik-start-q4` to your `~/.bashrc` and reload the file.
 
 ## Starting Jarvik
 
@@ -66,6 +66,15 @@ Alternatively you can run the dedicated wrapper script:
 bash start_Mistral_7B.sh
 # or using the alias
 jarvik-start-7b
+# (available after running `bash load.sh`)
+```
+
+Another helper script starts a pre-quantized Q4 model:
+
+```bash
+bash start_Jarvik_Q4.sh
+# or using the alias
+jarvik-start-q4
 # (available after running `bash load.sh`)
 ```
 

--- a/load.sh
+++ b/load.sh
@@ -8,6 +8,7 @@ if ! grep -q "# 🚀 Alias příkazy pro JARVIK" ~/.bashrc; then
 alias jarvik='bash $DIR/activate.sh'
 alias jarvik-start='bash $DIR/start_jarvik_mistral.sh'
 alias jarvik-start-7b='bash $DIR/start_Mistral_7B.sh'
+alias jarvik-start-q4='bash $DIR/start_Jarvik_Q4.sh'
 alias jarvik-status='bash $DIR/status.sh'
 alias jarvik-install='bash $DIR/install_jarvik.sh'
 alias jarvik-flask='bash $DIR/start_flask.sh'

--- a/start_Jarvik_Q4.sh
+++ b/start_Jarvik_Q4.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Wrapper to start Jarvik with the Jarvik Q4 quantized model
+DIR="$(cd "$(dirname "$0")" && pwd)"
+MODEL_NAME="jarvik-q4" bash "$DIR/start_jarvik_mistral.sh" "$@"
+


### PR DESCRIPTION
## Summary
- add `start_Jarvik_Q4.sh` for the Q4 quantized model
- expose new `jarvik-start-q4` alias in `load.sh`
- document the script and alias in README

## Testing
- `python3 -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_b_685bed568a6c8322aa7467652f60272e