### PR TITLE
Measure ask() duration

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -89,6 +89,8 @@
       document.getElementById("status").textContent = "⏳ Zpracovávám…";
       document.getElementById("activity").textContent = "Čekám na odpověď…";
       document.getElementById("duration").textContent = "";
+
+      // measure the time it takes to get a response
       const startTime = performance.now();
 
       const formData = new FormData();
@@ -115,7 +117,7 @@
 
       document.getElementById("message").value = "";
       fileInput.value = "";
-      document.getElementById("status").textContent = "🟢 Připraven.";
+      document.getElementById("status").textContent = `🟢 Připraven za ${elapsed} s.`;
       document.getElementById("activity").textContent = "";
     }
 


### PR DESCRIPTION
## Summary
- track start time before calling `fetch` in `ask()`
- show the response time in seconds both in the duration field and status line

## Testing
- `pre-commit` *(fails: no such command)*

------
https://chatgpt.com/codex/tasks/task_b_685c33c746dc832294713513606e19a7