### PR TITLE
Add configurable Flask port

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ all helper scripts use the `mistral` model from Ollama, but you can override the
 model by setting the `MODEL_NAME` environment variable.
 Jarvik keeps the entire conversation history unless you set the
 `MAX_MEMORY_ENTRIES` environment variable to limit how many exchanges are stored.
+The Flask API listens on port `8010` by default, but you can override this using
+the `FLASK_PORT` environment variable.
 
 ## Installation
 
@@ -210,8 +212,8 @@ The script pulls the newest repository files, performs an uninstall, installs th
 
 ## API Usage
 
-Jarvik exposes a few HTTP endpoints on port `8010` that can be consumed by
-external applications such as ChatGPT:
+Jarvik exposes a few HTTP endpoints on the configured Flask port
+(default `8010`) that can be consumed by external applications such as ChatGPT:
 
 * `POST /ask` – ask Jarvik a question. The conversation is stored in memory.
 * `POST /memory/add` – manually append a `{ "user": "...", "jarvik": "..." }`

--- a/main.py
+++ b/main.py
@@ -12,6 +12,8 @@ import tempfile
 
 # Allow custom model via environment variable
 MODEL_NAME = os.getenv("MODEL_NAME", "mistral")
+# Allow choosing the Flask port via environment variable
+FLASK_PORT = int(os.getenv("FLASK_PORT", 8010))
 
 # Set base directory relative to this file
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -196,5 +198,5 @@ def static_files(path):
     return app.send_static_file(path)
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=8010)
+    app.run(host="0.0.0.0", port=FLASK_PORT)
 

--- a/manual
+++ b/manual
@@ -3,6 +3,7 @@
 Tento krátký manuál popisuje základní kroky pro instalaci a spuštění Jarvika na lokálním stroji.
 
 Ve výchozím nastavení používají skripty model `mistral`. Pokud chcete používat jiný model, nastavte proměnnou `MODEL_NAME` při jejich spouštění.
+Flask API naslouchá na portu `8010`, který lze změnit proměnnou `FLASK_PORT`.
 
 ## Instalace
 
@@ -31,9 +32,10 @@ bash start_jarvik_mistral.sh
 jarvik-start
 ```
 Skript aktivuje virtuální prostředí, spustí Ollamu, zvolený model (výchozí
-mistral) a nakonec Flask server na portu 8010. Pokud model chybí, stáhne se
-automaticky. Pro jiný model nastavte proměnnou `MODEL_NAME` při spuštění –
-všechny dodané skripty ji nyní plně respektují. Například:
+mistral) a nakonec Flask server na portu 8010 (lze změnit proměnnou
+`FLASK_PORT`). Pokud model chybí, stáhne se automaticky. Pro jiný model
+nastavte proměnnou `MODEL_NAME` při spuštění – všechny dodané skripty ji nyní
+plně respektují. Například:
 
 ```bash
 MODEL_NAME="mistral:7b-Q4_K_M" bash start_jarvik_mistral.sh


### PR DESCRIPTION
## Summary
- let the Flask app pick a port from `FLASK_PORT`
- update README and manual to document `FLASK_PORT`

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_b_685c35fefe508322b8a39c2ea0463bb8