### PR TITLE
Make PDF and DOCX dependencies optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ This will append alias commands such as `jarvik-start`, `jarvik-status`,
 `jarvik-model`, `jarvik-flask`, `jarvik-ollama`, `jarvik-start-7b` and
 `jarvik-start-q4` to your `~/.bashrc` and reload the file.
 
+PDF and DOCX knowledge base files are supported when the optional packages
+`PyPDF2` and `python-docx` are installed. These are listed as extras in
+`requirements.txt`.
+
 ## Starting Jarvik
 
 To launch all components run:

--- a/rag_engine.py
+++ b/rag_engine.py
@@ -1,6 +1,4 @@
 import os
-import PyPDF2
-import docx
 import glob
 
 def load_txt_file(path):
@@ -8,6 +6,11 @@ def load_txt_file(path):
         return f.read()
 
 def load_pdf_file(path):
+    try:
+        import PyPDF2
+    except ImportError:
+        raise ImportError("PyPDF2 is required to load PDF files")
+
     text = ""
     with open(path, "rb") as f:
         reader = PyPDF2.PdfReader(f)
@@ -16,6 +19,11 @@ def load_pdf_file(path):
     return text
 
 def load_docx_file(path):
+    try:
+        import docx
+    except ImportError:
+        raise ImportError("python-docx is required to load DOCX files")
+
     doc = docx.Document(path)
     return "\n".join([p.text for p in doc.paragraphs])
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 flask
 requests
+# Optional extras for PDF/DOCX knowledge base support
 PyPDF2
 python-docx
 


### PR DESCRIPTION
## Summary
- defer `PyPDF2` and `python-docx` imports until their loader functions are called
- annotate optional packages in `requirements.txt`
- document optional PDF and DOCX support in the README

## Testing
- `python -m py_compile rag_engine.py main.py`

------
https://chatgpt.com/codex/tasks/task_b_685c38deda4c8322bc51ef7f3c80b9f7