### PR TITLE
Clarify TXT-only usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,17 @@ PDF and DOCX knowledge base files are supported when the optional packages
 `PyPDF2` and `python-docx` are installed. These are listed as extras in
 `requirements.txt`.
 
+### Text-only mode
+
+If you only work with plain text files you can simplify Jarvik:
+
+1. Edit `static/index.html` so the file input uses `accept=".txt"`.
+2. Remove the `.pdf` and `.docx` branches from the `/ask_file` handler in
+   `main.py`.
+
+After these changes Jarvik will only process TXT files and you may remove the
+`PyPDF2` and `python-docx` packages from your environment.
+
 ## Starting Jarvik
 
 To launch all components run:

--- a/main.py
+++ b/main.py
@@ -3,8 +3,6 @@ from rag_engine import (
     load_knowledge,
     search_knowledge,
     load_txt_file,
-    load_pdf_file,
-    load_docx_file,
 )
 import json
 import os
@@ -118,10 +116,6 @@ def ask_file():
         try:
             if ext == ".txt":
                 file_text = load_txt_file(tmp_path)
-            elif ext == ".pdf":
-                file_text = load_pdf_file(tmp_path)
-            elif ext == ".docx":
-                file_text = load_docx_file(tmp_path)
             else:
                 debug_log.append(f"Nepodporovaný typ souboru: {uploaded.filename}")
         except Exception as e:

--- a/static/index.html
+++ b/static/index.html
@@ -60,7 +60,7 @@
   <img src="/static/alternativ.png" alt="Jarvik logo">
 
   <textarea id="message" rows="4" placeholder="Zadej dotaz…"></textarea><br>
-  <input type="file" id="file" accept=".txt,.pdf,.docx"><br>
+  <input type="file" id="file" accept=".txt"><br>
   <button onclick="ask()">Odeslat</button>
   <pre id="activity"></pre>
 


### PR DESCRIPTION
## Summary
- add Text-only mode instructions for dropping PDF/DOCX logic
- simplify `ask_file` handler to only read TXT files
- limit file uploads in the UI to `.txt`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685c3c0575388322b48c7ee253b4c47d