### PR TITLE
Add dynamic model switching

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -59,6 +59,15 @@
 <body>
   <img src="/static/alternativ.png" alt="Jarvik logo">
 
+  <p>Aktivní model: <span id="current-model">?</span></p>
+  <select id="model-select">
+    <option value="mistral">mistral</option>
+    <option value="jarvik-q4">jarvik-q4</option>
+    <option value="mistral:7b-Q4_K_M">mistral:7b-Q4_K_M</option>
+  </select>
+  <button onclick="switchModel()">Přepnout model</button>
+  <pre id="model-status"></pre>
+
   <textarea id="message" rows="4" placeholder="Zadej dotaz…"></textarea><br>
   <input type="file" id="file" accept=".txt,.pdf,.docx"><br>
   <button onclick="ask()">Odeslat</button>
@@ -80,6 +89,27 @@
   <pre id="duration"></pre>
 
   <script>
+    async function loadModel() {
+      const res = await fetch('/model');
+      const data = await res.json();
+      document.getElementById('current-model').textContent = data.model;
+      const sel = document.getElementById('model-select');
+      if (sel) sel.value = data.model;
+    }
+
+    async function switchModel() {
+      const model = document.getElementById('model-select').value;
+      document.getElementById('model-status').textContent = '⏳ Restartuji...';
+      await fetch('/model', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model })
+      });
+      document.getElementById('model-status').textContent = '🔄 Restartuji, chvíli strpení...';
+    }
+
+    loadModel();
+
     let conversationLog = "";
 
     async function ask() {

--- a/switch_model.sh
+++ b/switch_model.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Helper to switch models by restarting all components
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$DIR" || exit
+
+NEW_MODEL="$1"
+if [ -z "$NEW_MODEL" ]; then
+  echo "Usage: $0 <model_name>" >&2
+  exit 1
+fi
+
+echo "🔄 Switching to model $NEW_MODEL..."
+
+# Stop running services
+pkill -f "python3 main.py" 2>/dev/null
+pkill -f "ollama run" 2>/dev/null
+pkill -f "ollama serve" 2>/dev/null
+sleep 2
+
+MODEL_NAME="$NEW_MODEL" bash "$DIR/start_jarvik_mistral.sh"


### PR DESCRIPTION
## Summary
- allow querying/setting the active model via new `/model` endpoint
- provide `switch_model.sh` helper to restart ollama, the model and Flask
- display current model in the web UI with a drop-down to switch models

## Testing
- `python3 -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_b_685c45ba2060832281e1043d0dff460a