### PR TITLE
Switch default Jarvik model to Gemma 2B

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Jarvik
 
 This repository contains scripts to run the Jarvik assistant locally. By default
-all helper scripts use the `mistral` model from Ollama, but you can override the
-model by setting the `MODEL_NAME` environment variable.
+all helper scripts use the `gemma:2b` model from Ollama, but you can override
+the model by setting the `MODEL_NAME` environment variable.
 Jarvik keeps the entire conversation history unless you set the
 `MAX_MEMORY_ENTRIES` environment variable to limit how many exchanges are stored.
 The Flask API listens on port `8010` by default, but you can override this using
@@ -34,7 +34,8 @@ bash load.sh
 
 This will append alias commands such as `jarvik-start`, `jarvik-status`,
 `jarvik-model`, `jarvik-flask`, `jarvik-ollama`, `jarvik-start-7b` and
-`jarvik-start-q4` to your `~/.bashrc` and reload the file.
+`jarvik-start-q4` to your `~/.bashrc` and reload the file. The `jarvik-start`
+alias launches the default Gemma 2B model.
 
 PDF and DOCX knowledge base files are supported when the optional packages
 `PyPDF2` and `python-docx` are installed. These are listed as extras in
@@ -56,11 +57,11 @@ After these changes Jarvik will only process TXT files and you may remove the
 To launch all components run:
 
 ```bash
-bash start_jarvik_mistral.sh
+bash start_jarvik.sh
 ```
 
 The script checks for required commands and automatically downloads the
-`mistral` model if it is missing. Po spuštění vypíše, zda se všechny části
+`gemma:2b` model if it is missing. Po spuštění vypíše, zda se všechny části
 správně nastartovaly, případné chyby hledejte v souborech `*.log`.
 With the aliases loaded you can simply type:
 
@@ -75,11 +76,17 @@ The Flask API will query whichever model is specified. To start Jarvik with any
 model simply set the variable when invoking the script. For example:
 
 ```bash
-MODEL_NAME="mistral:7b-Q4_K_M" bash start_jarvik_mistral.sh
+MODEL_NAME="mistral:7b-Q4_K_M" bash start_jarvik.sh
 ```
-Alternatively you can run the dedicated wrapper script:
+Alternatively you can run the dedicated wrapper scripts:
 
 ```bash
+# Default model
+bash start_Gemma_2B.sh
+# or using the alias
+jarvik-start
+
+# Mistral 7B model
 bash start_Mistral_7B.sh
 # or using the alias
 jarvik-start-7b
@@ -180,7 +187,7 @@ Jarvik can be stopped and fully removed using the uninstall script:
 bash uninstall_jarvik.sh
 ```
 
-The script stops Ollama, Mistral and Flask, removes the `venv/` and
+The script stops Ollama, the model and Flask, removes the `venv/` and
 `memory/` directories and cleans the Jarvik aliases from `~/.bashrc`.
 
 ## Quick Start Script
@@ -189,7 +196,7 @@ For a single command that activates the environment, loads the model and
 starts Flask you can also use the main start script:
 
 ```bash
-bash start_jarvik_mistral.sh
+bash start_jarvik.sh
 ```
 
 ## Real-time Monitoring
@@ -201,7 +208,7 @@ bash monitor.sh
 ```
 
 The script refreshes every two seconds and shows the last lines from
-`flask.log`, `<model>.log` and `ollama.log` produced by `start_jarvik_mistral.sh`.
+`flask.log`, `<model>.log` and `ollama.log` produced by `start_jarvik.sh`.
 
 ## Automatic Restart
 
@@ -212,7 +219,7 @@ restart missing processes automatically:
 bash watchdog.sh
 ```
 
-The watchdog checks every five seconds that Ollama, the Mistral model and
+The watchdog checks every five seconds that Ollama, the Gemma 2B model and
 the Flask server are up and restarts them when needed.
 
 ## Upgrade

--- a/load.sh
+++ b/load.sh
@@ -6,7 +6,7 @@ if ! grep -q "# 🚀 Alias příkazy pro JARVIK" ~/.bashrc; then
 
 # 🚀 Alias příkazy pro JARVIK
 alias jarvik='bash $DIR/activate.sh'
-alias jarvik-start='bash $DIR/start_jarvik_mistral.sh'
+alias jarvik-start='bash $DIR/start_Gemma_2B.sh'
 alias jarvik-start-7b='bash $DIR/start_Mistral_7B.sh'
 alias jarvik-start-q4='bash $DIR/start_Jarvik_Q4.sh'
 alias jarvik-status='bash $DIR/status.sh'

--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ import os
 import tempfile
 
 # Allow custom model via environment variable
-MODEL_NAME = os.getenv("MODEL_NAME", "mistral")
+MODEL_NAME = os.getenv("MODEL_NAME", "gemma:2b")
 # Allow choosing the Flask port via environment variable
 FLASK_PORT = int(os.getenv("FLASK_PORT", 8010))
 

--- a/manual
+++ b/manual
@@ -2,7 +2,7 @@
 
 Tento krátký manuál popisuje základní kroky pro instalaci a spuštění Jarvika na lokálním stroji.
 
-Ve výchozím nastavení používají skripty model `mistral`. Pokud chcete používat jiný model, nastavte proměnnou `MODEL_NAME` při jejich spouštění.
+Ve výchozím nastavení používají skripty model `gemma:2b`. Pokud chcete používat jiný model, nastavte proměnnou `MODEL_NAME` při jejich spouštění.
 Flask API naslouchá na portu `8010`, který lze změnit proměnnou `FLASK_PORT`.
 
 ## Instalace
@@ -25,20 +25,20 @@ Flask API naslouchá na portu `8010`, který lze změnit proměnnou `FLASK_PORT`
 
 ## Spuštění
 
-Jarvika spustíte buď přímo pomocí skriptu `start_jarvik_mistral.sh`, nebo přes alias `jarvik-start` (pokud jste provedli krok s načtením aliasů):
+Jarvika spustíte buď přímo pomocí skriptu `start_jarvik.sh`, nebo přes alias `jarvik-start` (pokud jste provedli krok s načtením aliasů):
 ```bash
-bash start_jarvik_mistral.sh
+bash start_Gemma_2B.sh
 # nebo
 jarvik-start
 ```
 Skript aktivuje virtuální prostředí, spustí Ollamu, zvolený model (výchozí
-mistral) a nakonec Flask server na portu 8010 (lze změnit proměnnou
+Gemma 2B) a nakonec Flask server na portu 8010 (lze změnit proměnnou
 `FLASK_PORT`). Pokud model chybí, stáhne se automaticky. Pro jiný model
 nastavte proměnnou `MODEL_NAME` při spuštění – všechny dodané skripty ji nyní
 plně respektují. Například:
 
 ```bash
-MODEL_NAME="mistral:7b-Q4_K_M" bash start_jarvik_mistral.sh
+MODEL_NAME="mistral:7b-Q4_K_M" bash start_jarvik.sh
 ```
 nebo použijte připravený skript pro Mistral 7B:
 
@@ -131,13 +131,13 @@ Pro zastavení všech služeb a odstranění prostředí použijte:
 ```bash
 bash uninstall_jarvik.sh
 ```
-Skript ukončí Ollamu, Mistral i Flask, smaže adresáře `venv/` a `memory/` a vyčistí aliasy z `~/.bashrc`.
+Skript ukončí Ollamu, spuštěný model i Flask, smaže adresáře `venv/` a `memory/` a vyčistí aliasy z `~/.bashrc`.
 
 ## Rychlý start
 
-Pro jednorázové spuštění všech komponent slouží skript `start_jarvik_mistral.sh`, který aktivuje prostředí, spustí model i server v jednom kroku:
+Pro jednorázové spuštění všech komponent slouží skript `start_jarvik.sh`, který aktivuje prostředí, spustí model i server v jednom kroku:
 ```bash
-bash start_jarvik_mistral.sh
+bash start_jarvik.sh
 ```
 
 ## Upgrade

--- a/monitor.sh
+++ b/monitor.sh
@@ -6,7 +6,7 @@ DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$DIR" || exit
 
 # Default model name if not provided
-MODEL_NAME=${MODEL_NAME:-mistral}
+MODEL_NAME=${MODEL_NAME:-"gemma:2b"}
 MODEL_LOG="${MODEL_NAME}.log"
 
 while true; do

--- a/start_Gemma_2B.sh
+++ b/start_Gemma_2B.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Wrapper to start Jarvik with the Gemma 2B model
+DIR="$(cd "$(dirname "$0")" && pwd)"
+MODEL_NAME="gemma:2b" bash "$DIR/start_jarvik.sh" "$@"
+

--- a/start_Jarvik_Q4.sh
+++ b/start_Jarvik_Q4.sh
@@ -2,5 +2,5 @@
 
 # Wrapper to start Jarvik with the Jarvik Q4 quantized model
 DIR="$(cd "$(dirname "$0")" && pwd)"
-MODEL_NAME="jarvik-q4" bash "$DIR/start_jarvik_mistral.sh" "$@"
+MODEL_NAME="jarvik-q4" bash "$DIR/start_jarvik.sh" "$@"
 

--- a/start_Mistral_7B.sh
+++ b/start_Mistral_7B.sh
@@ -2,5 +2,5 @@
 
 # Wrapper to start Jarvik with the Mistral 7B quantized model
 DIR="$(cd "$(dirname "$0")" && pwd)"
-MODEL_NAME="mistral:7b-Q4_K_M" bash "$DIR/start_jarvik_mistral.sh" "$@"
+MODEL_NAME="mistral:7b-Q4_K_M" bash "$DIR/start_jarvik.sh" "$@"
 

--- a/start_jarvik.sh
+++ b/start_jarvik.sh
@@ -6,7 +6,7 @@ NC="\033[0m"
 cd "$(dirname "$0")" || exit
 
 # Model name can be overridden with the MODEL_NAME environment variable
-MODEL_NAME=${MODEL_NAME:-mistral}
+MODEL_NAME=${MODEL_NAME:-"gemma:2b"}
 # Log file for the model output
 MODEL_LOG="${MODEL_NAME}.log"
 # Optional LOCAL_MODEL_FILE can specify a .gguf file to register as this model

--- a/start_model.sh
+++ b/start_model.sh
@@ -6,7 +6,7 @@ NC='\033[0m'
 cd "$(dirname "$0")" || exit
 
 # Default model name can be overridden via MODEL_NAME
-MODEL_NAME=${MODEL_NAME:-mistral}
+MODEL_NAME=${MODEL_NAME:-"gemma:2b"}
 MODEL_LOG="${MODEL_NAME}.log"
 # Optional local .gguf file to register as MODEL_NAME when not present
 # Set LOCAL_MODEL_FILE to the path of your .gguf file

--- a/status.sh
+++ b/status.sh
@@ -8,7 +8,7 @@ NC='\033[0m'
 if [ "$#" -gt 0 ]; then
   MODEL_NAMES="$*"
 else
-  MODEL_NAMES="${MODEL_NAMES:-${MODEL_NAME:-mistral}}"
+  MODEL_NAMES="${MODEL_NAMES:-${MODEL_NAME:-gemma:2b}}"
 fi
 
 echo "🔍 Kontrola systému JARVIK..."

--- a/uninstall_jarvik.sh
+++ b/uninstall_jarvik.sh
@@ -3,7 +3,7 @@ DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$DIR" || exit
 set -e
 # Default model name can be overridden via MODEL_NAME
-MODEL_NAME=${MODEL_NAME:-mistral}
+MODEL_NAME=${MODEL_NAME:-"gemma:2b"}
 
 echo "🗑️ Odinstalace Jarvika..."
 

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -37,6 +37,6 @@ fi
 bash load.sh
 
 # Start automatically
-bash start_jarvik_mistral.sh
+bash start_Gemma_2B.sh
 
 echo -e "${GREEN}✅ Upgrade dokončen.${NC}"

--- a/watchdog.sh
+++ b/watchdog.sh
@@ -10,7 +10,7 @@ else
   PORT_CHECK_AVAILABLE=false
 fi
 # Default model name can be overridden via MODEL_NAME
-MODEL_NAME=${MODEL_NAME:-mistral}
+MODEL_NAME=${MODEL_NAME:-"gemma:2b"}
 MODEL_LOG="${MODEL_NAME}.log"
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -30,7 +30,7 @@ check_ollama() {
   fi
 }
 
-check_mistral() {
+check_model() {
   if ! pgrep -f -x "ollama run $MODEL_NAME" > /dev/null; then
     echo -e "${RED}⚠️  Model $MODEL_NAME neběží. Restartuji...${NC}"
     nohup ollama run "$MODEL_NAME" >> "$MODEL_LOG" 2>&1 &
@@ -49,7 +49,7 @@ check_flask() {
 
 while true; do
   check_ollama
-  check_mistral
+  check_model
   check_flask
   sleep 5
 done


### PR DESCRIPTION
## Summary
- make Gemma 2B the default model
- rename `start_jarvik_mistral.sh` to `start_jarvik.sh`
- add a `start_Gemma_2B.sh` helper
- update aliases so `jarvik-start` launches Gemma 2B
- document the new defaults in README and the Czech manual

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685c464079ec8322af9a835f6d818a34