### PR TITLE
Add stop_all helper and auto-stop wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ jarvik-start-7b
 # (available after running `bash load.sh`)
 ```
 
+Switching models is seamless because each wrapper calls `stop_all.sh` before
+starting the selected model. Any running model or Flask instance is
+terminated automatically.
+
 Another helper script starts a pre-quantized Q4 model:
 
 ```bash
@@ -189,6 +193,12 @@ bash uninstall_jarvik.sh
 
 The script stops Ollama, the model and Flask, removes the `venv/` and
 `memory/` directories and cleans the Jarvik aliases from `~/.bashrc`.
+
+To merely stop the running services without removing anything, execute:
+
+```bash
+bash stop_all.sh
+```
 
 ## Quick Start Script
 

--- a/manual
+++ b/manual
@@ -48,6 +48,9 @@ bash start_Mistral_7B.sh
 jarvik-start-7b
 # (k dispozici po spuštění `bash load.sh`)
 ```
+Každý z těchto skriptů nejprve spustí `stop_all.sh`,
+který ukončí běžící model i Flask. Přepnutí na jiný model je tak otázkou
+jednoho příkazu.
 Stejnou hodnotu používá i samotná Flask aplikace.
 
 ### Offline použití
@@ -132,6 +135,12 @@ Pro zastavení všech služeb a odstranění prostředí použijte:
 bash uninstall_jarvik.sh
 ```
 Skript ukončí Ollamu, spuštěný model i Flask, smaže adresáře `venv/` a `memory/` a vyčistí aliasy z `~/.bashrc`.
+
+Pokud chcete pouze zastavit běžící model a Flask bez mazání souborů, spusťte
+
+```bash
+bash stop_all.sh
+```
 
 ## Rychlý start
 

--- a/start_Gemma_2B.sh
+++ b/start_Gemma_2B.sh
@@ -2,5 +2,7 @@
 
 # Wrapper to start Jarvik with the Gemma 2B model
 DIR="$(cd "$(dirname "$0")" && pwd)"
+# Stop any running instance before starting a new one
+bash "$DIR/stop_all.sh"
 MODEL_NAME="gemma:2b" bash "$DIR/start_jarvik.sh" "$@"
 

--- a/start_Jarvik_Q4.sh
+++ b/start_Jarvik_Q4.sh
@@ -2,5 +2,7 @@
 
 # Wrapper to start Jarvik with the Jarvik Q4 quantized model
 DIR="$(cd "$(dirname "$0")" && pwd)"
+# Stop any running instance before starting a new one
+bash "$DIR/stop_all.sh"
 MODEL_NAME="jarvik-q4" bash "$DIR/start_jarvik.sh" "$@"
 

--- a/start_Mistral_7B.sh
+++ b/start_Mistral_7B.sh
@@ -2,5 +2,7 @@
 
 # Wrapper to start Jarvik with the Mistral 7B quantized model
 DIR="$(cd "$(dirname "$0")" && pwd)"
+# Stop any running instance before starting a new one
+bash "$DIR/stop_all.sh"
 MODEL_NAME="mistral:7b-Q4_K_M" bash "$DIR/start_jarvik.sh" "$@"
 

--- a/stop_all.sh
+++ b/stop_all.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Stop Ollama, running models and Flask
+DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$DIR" || exit
+
+# Terminate Ollama server
+pkill -f "ollama serve" 2>/dev/null && echo "Stopped ollama serve" || true
+# Terminate any running models
+pkill -f "ollama run" 2>/dev/null && echo "Stopped running models" || true
+# Terminate Flask application
+pkill -f "python3 main.py" 2>/dev/null && echo "Stopped Flask" || true


### PR DESCRIPTION
## Summary
- provide `stop_all.sh` to stop Ollama, model and Flask
- invoke `stop_all.sh` from model start scripts
- document stopping behavior in README and manual

## Testing
- `bash -n stop_all.sh`
- `bash -n start_Gemma_2B.sh`
- `bash -n start_Mistral_7B.sh`
- `bash -n start_Jarvik_Q4.sh`


------
https://chatgpt.com/codex/tasks/task_b_685c4a811fd88322b6a7750d2986c83c