### PR TITLE
Update docs for Gemma 2B default model

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,17 @@ jarvik-start-q4
 # (available after running `bash load.sh`)
 ```
 
+### Switching models while running
+
+Jarvik can change models on the fly. Send a POST request to `/model` with
+`{"model": "name"}` or run the helper script `switch_model.sh`:
+
+```bash
+bash switch_model.sh mistral:7b-Q4_K_M
+```
+
+The application restarts with the new model.
+
 ### Offline usage
 
 If you need to run without internet access, first download the model file (for

--- a/manual
+++ b/manual
@@ -50,6 +50,18 @@ jarvik-start-7b
 ```
 Stejnou hodnotu používá i samotná Flask aplikace.
 
+### Přepnutí modelu za běhu
+
+Jarvika lze přepnout na jiný model bez ručního zastavení všech služeb.
+Stačí spustit skript `switch_model.sh` s názvem požadovaného modelu:
+
+```bash
+bash switch_model.sh mistral:7b-Q4_K_M
+```
+
+Případně je možné odeslat HTTP POST požadavek na `/model` s JSON
+`{"model": "jméno"}`. Aplikace se restartuje s novým modelem.
+
 ### Offline použití
 
 Pokud nemáte k dispozici internetové připojení, stáhněte si nejprve soubor s

--- a/monitor.sh
+++ b/monitor.sh
@@ -25,7 +25,7 @@ while true; do
   fi
 
   if [ -f "$MODEL_LOG" ]; then
-    echo "--- Poslední logy Mistralu ---"
+    echo "--- Poslední logy modelu ---"
     tail -n 5 "$MODEL_LOG"
   echo
   else

--- a/switch_model.sh
+++ b/switch_model.sh
@@ -18,4 +18,4 @@ pkill -f "ollama run" 2>/dev/null
 pkill -f "ollama serve" 2>/dev/null
 sleep 2
 
-MODEL_NAME="$NEW_MODEL" bash "$DIR/start_jarvik_mistral.sh"
+MODEL_NAME="$NEW_MODEL" bash "$DIR/start_jarvik.sh"


### PR DESCRIPTION
## Summary
- document Gemma 2B as default and show how to switch models
- reference the new switch script from README and manual
- update monitor text and fix switch_model.sh path

## Testing
- `python3 -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_b_685c4a77e37c8322b9ed4188ab322713