### PR TITLE
Add model switch wrappers

### DIFF
--- a/load.sh
+++ b/load.sh
@@ -14,6 +14,13 @@ alias jarvik-install='bash $DIR/install_jarvik.sh'
 alias jarvik-flask='bash $DIR/start_flask.sh'
 alias jarvik-model='bash $DIR/start_model.sh'
 alias jarvik-ollama='bash $DIR/start_ollama.sh'
+alias jarvik-start-phi3='bash $DIR/start_phi3_mini.sh'
+alias jarvik-start-nh2='bash $DIR/start_nous_hermes2.sh'
+alias jarvik-start-llama3='bash $DIR/start_llama3_8b.sh'
+alias jarvik-start-command-r='bash $DIR/start_command_r.sh'
+alias jarvik-start-zephyr='bash $DIR/start_zephyr.sh'
+alias jarvik-start-coder='bash $DIR/start_deepseek_coder.sh'
+alias jarvik-start-gemma='bash $DIR/start_gemma_2b.sh'
 
 EOF
 fi

--- a/start_command_r.sh
+++ b/start_command_r.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+DIR="$(cd "$(dirname "$0")" && pwd)"
+bash "$DIR/switch_model.sh" "command-r" "$@"

--- a/start_deepseek_coder.sh
+++ b/start_deepseek_coder.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+DIR="$(cd "$(dirname "$0")" && pwd)"
+bash "$DIR/switch_model.sh" "deepseek-coder:6.7b" "$@"

--- a/start_gemma_2b.sh
+++ b/start_gemma_2b.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+DIR="$(cd "$(dirname "$0")" && pwd)"
+bash "$DIR/switch_model.sh" "gemma:2b" "$@"

--- a/start_llama3_8b.sh
+++ b/start_llama3_8b.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+DIR="$(cd "$(dirname "$0")" && pwd)"
+bash "$DIR/switch_model.sh" "llama3:8b" "$@"

--- a/start_nous_hermes2.sh
+++ b/start_nous_hermes2.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+DIR="$(cd "$(dirname "$0")" && pwd)"
+bash "$DIR/switch_model.sh" "nous-hermes2:7b" "$@"

--- a/start_phi3_mini.sh
+++ b/start_phi3_mini.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+DIR="$(cd "$(dirname "$0")" && pwd)"
+bash "$DIR/switch_model.sh" "phi3:mini" "$@"

--- a/start_zephyr.sh
+++ b/start_zephyr.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+DIR="$(cd "$(dirname "$0")" && pwd)"
+bash "$DIR/switch_model.sh" "zephyr" "$@"


### PR DESCRIPTION
## Summary
- add lightweight scripts to switch to various models
- expose new convenience aliases in `load.sh`

## Testing
- `bash -n start_phi3_mini.sh`
- `bash -n start_nous_hermes2.sh`
- `bash -n start_llama3_8b.sh`
- `bash -n start_command_r.sh`
- `bash -n start_zephyr.sh`
- `bash -n start_deepseek_coder.sh`
- `bash -n start_gemma_2b.sh`
- `bash -n load.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685c4c1a00088322b6f978b9f9f87138