### PR TITLE
Set Gemma 2B as default model

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Alternatively you can run the dedicated wrapper scripts:
 
 ```bash
 # Default model
-bash start_Gemma_2B.sh
+bash start_jarvik.sh
 # or using the alias
 jarvik-start
 

--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ import os
 import tempfile
 import subprocess
 
-# Allow custom model via environment variable
+# Allow custom model via environment variable (default Gemma 2B)
 MODEL_NAME = os.getenv("MODEL_NAME", "gemma:2b")
 # Allow choosing the Flask port via environment variable
 FLASK_PORT = int(os.getenv("FLASK_PORT", 8010))

--- a/manual
+++ b/manual
@@ -25,9 +25,9 @@ Flask API naslouchá na portu `8010`, který lze změnit proměnnou `FLASK_PORT`
 
 ## Spuštění
 
-Jarvika spustíte buď přímo pomocí skriptu `start_jarvik.sh`, nebo přes alias `jarvik-start` (pokud jste provedli krok s načtením aliasů):
+# Jarvika spustíte buď přímo pomocí skriptu `start_jarvik.sh`, nebo přes alias `jarvik-start` (pokud jste provedli krok s načtením aliasů):
 ```bash
-bash start_Gemma_2B.sh
+bash start_jarvik.sh
 # nebo
 jarvik-start
 ```

--- a/monitor.sh
+++ b/monitor.sh
@@ -25,7 +25,7 @@ while true; do
   fi
 
   if [ -f "$MODEL_LOG" ]; then
-    echo "--- Poslední logy Mistralu ---"
+    echo "--- Poslední logy modelu ($MODEL_NAME) ---"
     tail -n 5 "$MODEL_LOG"
   echo
   else

--- a/start_jarvik.sh
+++ b/start_jarvik.sh
@@ -5,7 +5,7 @@ NC="\033[0m"
 
 cd "$(dirname "$0")" || exit
 
-# Model name can be overridden with the MODEL_NAME environment variable
+# Model name (Gemma 2B by default) can be overridden with MODEL_NAME
 MODEL_NAME=${MODEL_NAME:-"gemma:2b"}
 # Log file for the model output
 MODEL_LOG="${MODEL_NAME}.log"

--- a/start_model.sh
+++ b/start_model.sh
@@ -5,7 +5,7 @@ NC='\033[0m'
 
 cd "$(dirname "$0")" || exit
 
-# Default model name can be overridden via MODEL_NAME
+# Default model name (Gemma 2B) can be overridden via MODEL_NAME
 MODEL_NAME=${MODEL_NAME:-"gemma:2b"}
 MODEL_LOG="${MODEL_NAME}.log"
 # Optional local .gguf file to register as MODEL_NAME when not present

--- a/status.sh
+++ b/status.sh
@@ -8,6 +8,7 @@ NC='\033[0m'
 if [ "$#" -gt 0 ]; then
   MODEL_NAMES="$*"
 else
+  # Gemma 2B is used when MODEL_NAME is unset
   MODEL_NAMES="${MODEL_NAMES:-${MODEL_NAME:-gemma:2b}}"
 fi
 

--- a/switch_model.sh
+++ b/switch_model.sh
@@ -18,4 +18,4 @@ pkill -f "ollama run" 2>/dev/null
 pkill -f "ollama serve" 2>/dev/null
 sleep 2
 
-MODEL_NAME="$NEW_MODEL" bash "$DIR/start_jarvik_mistral.sh"
+MODEL_NAME="$NEW_MODEL" bash "$DIR/start_jarvik.sh"

--- a/uninstall_jarvik.sh
+++ b/uninstall_jarvik.sh
@@ -2,7 +2,7 @@
 DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$DIR" || exit
 set -e
-# Default model name can be overridden via MODEL_NAME
+# Default model name (Gemma 2B) can be overridden via MODEL_NAME
 MODEL_NAME=${MODEL_NAME:-"gemma:2b"}
 
 echo "🗑️ Odinstalace Jarvika..."

--- a/watchdog.sh
+++ b/watchdog.sh
@@ -9,7 +9,7 @@ else
   echo -e "${RED}⚠️  Příkazy 'ss' ani 'nc' nebyly nalezeny. Kontrola portu Flask bude přeskočena.${NC}"
   PORT_CHECK_AVAILABLE=false
 fi
-# Default model name can be overridden via MODEL_NAME
+# Default model name (Gemma 2B) can be overridden via MODEL_NAME
 MODEL_NAME=${MODEL_NAME:-"gemma:2b"}
 MODEL_LOG="${MODEL_NAME}.log"
 


### PR DESCRIPTION
## Summary
- note Gemma 2B as default in main.py and shell scripts
- adjust status and monitor messages
- use `start_jarvik.sh` from switch_model.sh
- update docs/examples to call `start_jarvik.sh`

## Testing
- `bash -n start_jarvik.sh start_model.sh switch_model.sh monitor.sh watchdog.sh uninstall_jarvik.sh status.sh`
- `python3 -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_b_685c4b3d37188322ae17b54f92d6dd40