### PR TITLE
Add wrapper scripts for various models

### DIFF
--- a/start_Command_R.sh
+++ b/start_Command_R.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Wrapper to start Jarvik with the command-r model
+DIR="$(cd "$(dirname "$0")" && pwd)"
+bash "$DIR/switch_model.sh" "command-r"

--- a/start_Deepseek_Coder.sh
+++ b/start_Deepseek_Coder.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Wrapper to start Jarvik with the deepseek-coder model
+DIR="$(cd "$(dirname "$0")" && pwd)"
+bash "$DIR/switch_model.sh" "deepseek-coder"

--- a/start_Gemma_2B.sh
+++ b/start_Gemma_2B.sh
@@ -3,6 +3,5 @@
 # Wrapper to start Jarvik with the Gemma 2B model
 DIR="$(cd "$(dirname "$0")" && pwd)"
 # Stop any running instance before starting a new one
-bash "$DIR/stop_all.sh"
-MODEL_NAME="gemma:2b" bash "$DIR/start_jarvik.sh" "$@"
+bash "$DIR/switch_model.sh" "gemma:2b"
 

--- a/start_Jarvik_Q4.sh
+++ b/start_Jarvik_Q4.sh
@@ -3,6 +3,5 @@
 # Wrapper to start Jarvik with the Jarvik Q4 quantized model
 DIR="$(cd "$(dirname "$0")" && pwd)"
 # Stop any running instance before starting a new one
-bash "$DIR/stop_all.sh"
-MODEL_NAME="jarvik-q4" bash "$DIR/start_jarvik.sh" "$@"
+bash "$DIR/switch_model.sh" "jarvik-q4"
 

--- a/start_Llama3_8B.sh
+++ b/start_Llama3_8B.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Wrapper to start Jarvik with the llama3:8b model
+DIR="$(cd "$(dirname "$0")" && pwd)"
+bash "$DIR/switch_model.sh" "llama3:8b"

--- a/start_Mistral_7B.sh
+++ b/start_Mistral_7B.sh
@@ -3,6 +3,5 @@
 # Wrapper to start Jarvik with the Mistral 7B quantized model
 DIR="$(cd "$(dirname "$0")" && pwd)"
 # Stop any running instance before starting a new one
-bash "$DIR/stop_all.sh"
-MODEL_NAME="mistral:7b-Q4_K_M" bash "$DIR/start_jarvik.sh" "$@"
+bash "$DIR/switch_model.sh" "mistral:7b-Q4_K_M"
 

--- a/start_Nous_Hermes2.sh
+++ b/start_Nous_Hermes2.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Wrapper to start Jarvik with the nous-hermes2 model
+DIR="$(cd "$(dirname "$0")" && pwd)"
+bash "$DIR/switch_model.sh" "nous-hermes2"

--- a/start_Phi3_Mini.sh
+++ b/start_Phi3_Mini.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Wrapper to start Jarvik with the phi3:mini model
+DIR="$(cd "$(dirname "$0")" && pwd)"
+bash "$DIR/switch_model.sh" "phi3:mini"

--- a/start_Zephyr.sh
+++ b/start_Zephyr.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Wrapper to start Jarvik with the zephyr model
+DIR="$(cd "$(dirname "$0")" && pwd)"
+bash "$DIR/switch_model.sh" "zephyr"

--- a/switch_model.sh
+++ b/switch_model.sh
@@ -18,4 +18,4 @@ pkill -f "ollama run" 2>/dev/null
 pkill -f "ollama serve" 2>/dev/null
 sleep 2
 
-MODEL_NAME="$NEW_MODEL" bash "$DIR/start_jarvik_mistral.sh"
+MODEL_NAME="$NEW_MODEL" bash "$DIR/start_jarvik.sh"


### PR DESCRIPTION
## Summary
- make `switch_model.sh` invoke `start_jarvik.sh`
- update model launchers to use `switch_model.sh`
- add wrappers for phi3:mini, nous-hermes2, llama3:8b, command-r, zephyr and deepseek-coder

## Testing
- `bash -n switch_model.sh start_Mistral_7B.sh start_Jarvik_Q4.sh start_Gemma_2B.sh start_Command_R.sh start_Deepseek_Coder.sh start_Llama3_8B.sh start_Nous_Hermes2.sh start_Phi3_Mini.sh start_Zephyr.sh`

------
https://chatgpt.com/codex/tasks/task_b_685c4c12d8e48322a550f90c943476e1