### PR TITLE
Update docs for model switching and /model endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,17 @@ With the aliases loaded you can simply type:
 jarvik-start
 ```
 
+When the web interface is open, a drop-down menu at the top lets you
+restart Jarvik with another model. Selecting a value calls the new
+`/model` API endpoint which stops the current components and launches
+the chosen model.
+
 ### Running with a different model
 
-All management scripts now fully honour the `MODEL_NAME` environment variable.
-The Flask API will query whichever model is specified. To start Jarvik with any
-model simply set the variable when invoking the script. For example:
+Gemma 2B is used by default. All management scripts fully honour the
+`MODEL_NAME` environment variable and the Flask API will query whatever
+model is specified. To start Jarvik with any model simply set the variable
+when invoking the script. For example:
 
 ```bash
 MODEL_NAME="mistral:7b-Q4_K_M" bash start_jarvik.sh
@@ -101,6 +107,15 @@ bash start_Jarvik_Q4.sh
 jarvik-start-q4
 # (available after running `bash load.sh`)
 ```
+
+To change the running model later on, execute:
+
+```bash
+bash switch_model.sh <model>
+```
+
+The command stops the current services and restarts Jarvik with the
+specified model.
 
 ### Offline usage
 
@@ -243,6 +258,8 @@ Jarvik exposes a few HTTP endpoints on the configured Flask port
 * `GET /memory/search?q=term` – search stored memory entries. When no query is
   provided, the last five entries are returned.
 * `GET /knowledge/search?q=term` – search the local knowledge base files.
+* `GET /model` – return the name of the active model.
+* `POST /model` – restart Jarvik with the specified `{ "model": "name" }`.
 
 ## License
 

--- a/manual
+++ b/manual
@@ -36,6 +36,9 @@ Gemma 2B) a nakonec Flask server na portu 8010 (lze změnit proměnnou
 `FLASK_PORT`). Pokud model chybí, stáhne se automaticky. Pro jiný model
 nastavte proměnnou `MODEL_NAME` při spuštění – všechny dodané skripty ji nyní
 plně respektují. Například:
+Z webového rozhraní lze model přepnout rozbalovacím seznamem nahoře. Po
+výběru se zavolá nová cesta `/model`, která Jarvika restartuje s vybraným
+modelem.
 
 ```bash
 MODEL_NAME="mistral:7b-Q4_K_M" bash start_jarvik.sh
@@ -49,6 +52,14 @@ jarvik-start-7b
 # (k dispozici po spuštění `bash load.sh`)
 ```
 Stejnou hodnotu používá i samotná Flask aplikace.
+
+Kdykoli později můžete model změnit příkazem:
+
+```bash
+bash switch_model.sh <model>
+```
+
+Skript ukončí běžící služby a znovu spustí Jarvika s novým modelem.
 
 ### Offline použití
 
@@ -147,3 +158,16 @@ Nejnovější verzi můžete stáhnout a nainstalovat skriptem `upgrade.sh`:
 bash upgrade.sh
 ```
 Skript stáhne nové soubory z repozitáře, provede odinstalování, znovu nainstaluje závislosti, obnoví aliasy v `~/.bashrc` a spustí Jarvika.
+
+## API
+
+Jarvik zpřístupňuje několik HTTP cest na portu 8010 (lze změnit proměnnou
+`FLASK_PORT`):
+
+* `POST /ask` – pošle dotaz Jarvikovi a uloží konverzaci do paměti.
+* `POST /memory/add` – ručně přidá záznam `{ "user": "...", "jarvik": "..." }`.
+* `GET /memory/search?q=dotaz` – vyhledá uložené záznamy, bez dotazu vrátí
+  posledních pět.
+* `GET /knowledge/search?q=dotaz` – prohledá lokální znalostní soubory.
+* `GET /model` – vrátí název aktuálně používaného modelu.
+* `POST /model` – restartuje Jarvika s modelem uvedeným v JSONu `{ "model": "nazev" }`.


### PR DESCRIPTION
## Summary
- document UI model selector and switching script
- mention Gemma 2B as default and explain how to swap models
- add `/model` endpoint in API section
- mirror the updates in the Czech manual

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685c4a8359ec8322b8885c4b3604db56