### PR TITLE
Add more models to dropdown

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -67,6 +67,13 @@
   <h2 id="current-model-display">Running model: <span id="current-model">?</span></h2>
   <select id="model-select">
     <option value="gemma:2b">Gemma 2B</option>
+    <option value="phi3:mini">Phi3 Mini</option>
+    <option value="mistral">Mistral</option>
+    <option value="nous-hermes2">Nous Hermes2</option>
+    <option value="llama3:8b">Llama3 8B</option>
+    <option value="command-r">Command R</option>
+    <option value="zephyr">Zephyr</option>
+    <option value="deepseek-coder">Deepseek Coder</option>
     <option value="mistral:7b-Q4_K_M">Mistral 7B</option>
     <option value="jarvik-q4">Jarvik Q4</option>
   </select>
@@ -96,6 +103,13 @@
   <script>
     const MODEL_NAMES = {
       'gemma:2b': 'Gemma 2B',
+      'phi3:mini': 'Phi3 Mini',
+      'mistral': 'Mistral',
+      'nous-hermes2': 'Nous Hermes2',
+      'llama3:8b': 'Llama3 8B',
+      'command-r': 'Command R',
+      'zephyr': 'Zephyr',
+      'deepseek-coder': 'Deepseek Coder',
       'mistral:7b-Q4_K_M': 'Mistral 7B',
       'jarvik-q4': 'Jarvik Q4'
     };
@@ -106,7 +120,14 @@
       const name = MODEL_NAMES[data.model] || data.model;
       document.getElementById('current-model').textContent = name;
       const sel = document.getElementById('model-select');
-      if (sel) sel.value = data.model;
+      if (sel) {
+        let opt = Array.from(sel.options).find(o => o.value === data.model);
+        if (!opt) {
+          opt = new Option(name, data.model);
+          sel.appendChild(opt);
+        }
+        sel.value = data.model;
+      }
     }
 
     async function switchModel() {


### PR DESCRIPTION
## Summary
- list more available models in the UI dropdown
- show the current model even if the dropdown didn't previously list it

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685c4f5393808322933b951727d303ba