### PR TITLE
Fix docs for switch_model workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,10 +236,11 @@ bash uninstall_jarvik.sh
 The script stops Ollama, the model and Flask, removes the `venv/` and
 `memory/` directories and cleans the Jarvik aliases from `~/.bashrc`.
 
-To merely stop the running services without removing anything, execute:
+Chcete-li pouze přepnout na jiný model nebo znovu spustit Jarvik, využijte
+skript `switch_model.sh` se jménem požadovaného modelu:
 
 ```bash
-bash stop_all.sh
+bash switch_model.sh mistral:7b-Q4_K_M
 ```
 
 ## Quick Start Script

--- a/manual
+++ b/manual
@@ -27,7 +27,7 @@ Flask API naslouchá na portu `8010`, který lze změnit proměnnou `FLASK_PORT`
 
 Jarvika spustíte buď přímo pomocí skriptu `start_jarvik.sh`, nebo přes alias `jarvik-start` (pokud jste provedli krok s načtením aliasů):
 ```bash
-bash start_Gemma_2B.sh
+bash start_gemma_2b.sh
 # nebo
 jarvik-start
 ```
@@ -43,7 +43,7 @@ MODEL_NAME="mistral:7b-Q4_K_M" bash start_jarvik.sh
 nebo použijte připravený skript pro Mistral 7B:
 
 ```bash
-bash start_Mistral_7B.sh
+bash start_mistral_7b.sh
 # nebo
 jarvik-start-7b
 # (k dispozici po spuštění `bash load.sh`)
@@ -52,16 +52,17 @@ jarvik-start-7b
 Podobné skripty jsou připraveny i pro další modely:
 
 ```bash
-bash start_Jarvik_Q4.sh      # jarvik-q4
-bash start_Llama3_8B.sh      # llama3:8b
-bash start_Command_R.sh      # command-r
-bash start_Deepseek_Coder.sh # deepseek-coder
-bash start_Nous_Hermes2.sh   # nous-hermes2
-bash start_Phi3_Mini.sh      # phi3:mini
-bash start_Zephyr.sh         # zephyr
+bash start_jarvik_q4.sh      # jarvik-q4
+bash start_llama3_8b.sh      # llama3:8b
+bash start_command_r.sh      # command-r
+bash start_deepseek_coder.sh # deepseek-coder
+bash start_nous_hermes2.sh   # nous-hermes2
+bash start_phi3_mini.sh      # phi3:mini
+bash start_zephyr.sh         # zephyr
 ```
-Každý z těchto skriptů nejprve spustí `stop_all.sh`,
-který ukončí běžící model i Flask. Přepnutí na jiný model je tak otázkou
+Každý z těchto skriptů volá `switch_model.sh`,
+který nejprve zastaví běžící model i Flask a poté
+spustí novou instanci s vybraným modelem. Přepnutí je tak otázkou
 jednoho příkazu.
 Stejnou hodnotu používá i samotná Flask aplikace.
 
@@ -178,10 +179,10 @@ bash uninstall_jarvik.sh
 ```
 Skript ukončí Ollamu, spuštěný model i Flask, smaže adresáře `venv/` a `memory/` a vyčistí aliasy z `~/.bashrc`.
 
-Pokud chcete pouze zastavit běžící model a Flask bez mazání souborů, spusťte
+Pokud potřebujete Jarvika jen restartovat s jiným modelem, použijte
 
 ```bash
-bash stop_all.sh
+bash switch_model.sh mistral:7b-Q4_K_M
 ```
 
 ## Rychlý start


### PR DESCRIPTION
## Summary
- remove outdated `stop_all.sh` docs and emphasize using `switch_model.sh`
- normalize wrapper script names in the manual

## Testing
- `bash -n switch_model.sh`
- `for f in *.sh; do bash -n "$f" || echo "Error in $f"; done`
- `python -m py_compile main.py rag_engine.py`

------
https://chatgpt.com/codex/tasks/task_b_685c7ad5a4208322aaefd4238a4fd196