### PR TITLE
Allow custom Flask port

### DIFF
--- a/start_flask.sh
+++ b/start_flask.sh
@@ -3,6 +3,9 @@ GREEN='\033[1;32m'
 RED='\033[1;31m'
 NC='\033[0m'
 
+# Allow overriding the Flask port
+FLASK_PORT=${FLASK_PORT:-8010}
+
 cd "$(dirname "$0")" || exit
 
 # Activate virtual environment
@@ -19,19 +22,19 @@ echo -e "${GREEN}🌐 Spouštím Flask server...${NC}"
 nohup python3 main.py > flask.log 2>&1 &
 sleep 2
 
-# Verify port 8010 is listening
+# Verify the configured port is listening
 if command -v ss >/dev/null 2>&1; then
-  ss -tuln | grep -q ":8010"
+  ss -tuln | grep -q ":$FLASK_PORT"
   running=$?
 elif command -v nc >/dev/null 2>&1; then
-  nc -z localhost 8010 >/dev/null 2>&1
+  nc -z localhost $FLASK_PORT >/dev/null 2>&1
   running=$?
 else
   running=1
 fi
 
 if [ "$running" = 0 ]; then
-  echo -e "${GREEN}✅ Flask běží na http://localhost:8010${NC}"
+  echo -e "${GREEN}✅ Flask běží na http://localhost:$FLASK_PORT${NC}"
 else
   echo -e "${RED}❌ Flask se nespustil, zkontrolujte flask.log${NC}"
   exit 1

--- a/start_jarvik.sh
+++ b/start_jarvik.sh
@@ -3,6 +3,9 @@ GREEN="\033[1;32m"
 RED="\033[1;31m"
 NC="\033[0m"
 
+# Allow overriding the Flask port
+FLASK_PORT=${FLASK_PORT:-8010}
+
 cd "$(dirname "$0")" || exit
 
 # Model name can be overridden with the MODEL_NAME environment variable
@@ -88,8 +91,8 @@ fi
 echo -e "${GREEN}🌐 Spouštím Flask server...${NC}"
 nohup python3 main.py > flask.log 2>&1 &
 sleep 2
-if ! (ss -tuln 2>/dev/null | grep -q ":8010" || nc -z localhost 8010 >/dev/null 2>&1); then
+if ! (ss -tuln 2>/dev/null | grep -q ":$FLASK_PORT" || nc -z localhost $FLASK_PORT >/dev/null 2>&1); then
   echo -e "${RED}❌ Flask se nespustil, zkontrolujte flask.log${NC}"
   exit 1
 fi
-echo -e "${GREEN}✅ Jarvik běží na http://localhost:8010${NC}"
+echo -e "${GREEN}✅ Jarvik běží na http://localhost:$FLASK_PORT${NC}"

--- a/status.sh
+++ b/status.sh
@@ -4,6 +4,9 @@ GREEN='\033[1;32m'
 RED='\033[1;31m'
 NC='\033[0m'
 
+# Allow overriding the Flask port
+FLASK_PORT=${FLASK_PORT:-8010}
+
 # Determine which model(s) to check
 if [ "$#" -gt 0 ]; then
   MODEL_NAMES="$*"
@@ -55,20 +58,20 @@ for MODEL_NAME in $MODEL_NAMES; do
   fi
 done
 
-# Flask port 8010
+# Flask port
 if command -v ss >/dev/null 2>&1; then
-  ss -tuln | grep -q ":8010"
+  ss -tuln | grep -q ":$FLASK_PORT"
   port_check=$?
 elif command -v nc >/dev/null 2>&1; then
-  nc -z localhost 8010 >/dev/null 2>&1
+  nc -z localhost $FLASK_PORT >/dev/null 2>&1
   port_check=$?
 else
   port_check=1
 fi
 if [ "$port_check" = 0 ]; then
-  echo -e "✅ Flask běží (port 8010)"
+  echo -e "✅ Flask běží (port $FLASK_PORT)"
 else
-  echo -e "❌ Flask (port 8010) neběží"
+  echo -e "❌ Flask (port $FLASK_PORT) neběží"
 fi
 
 # Paměť

--- a/watchdog.sh
+++ b/watchdog.sh
@@ -2,6 +2,8 @@
 GREEN="\033[1;32m"
 RED="\033[1;31m"
 NC="\033[0m"
+# Allow overriding the Flask port
+FLASK_PORT=${FLASK_PORT:-8010}
 # Determine if we can perform port checks
 if command -v ss >/dev/null 2>&1 || command -v nc >/dev/null 2>&1; then
   PORT_CHECK_AVAILABLE=true
@@ -41,7 +43,7 @@ check_flask() {
   if [ "$PORT_CHECK_AVAILABLE" = false ]; then
     return
   fi
-  if ! (ss -tuln 2>/dev/null | grep -q ":8010" || nc -z localhost 8010 >/dev/null 2>&1); then
+  if ! (ss -tuln 2>/dev/null | grep -q ":$FLASK_PORT" || nc -z localhost $FLASK_PORT >/dev/null 2>&1); then
     echo -e "${RED}⚠️  Flask neběží. Restartuji...${NC}"
     nohup python3 main.py >> flask.log 2>&1 &
   fi


### PR DESCRIPTION
## Summary
- add `FLASK_PORT` variable to startup scripts
- use the configured port in Flask checks and status reports

## Testing
- `bash -n start_jarvik.sh start_flask.sh status.sh watchdog.sh`

------
https://chatgpt.com/codex/tasks/task_b_685cda21454083228f9e8a21dcf4a2cd