### PR TITLE
Fix uninstall script to kill all models

### DIFF
--- a/uninstall_jarvik.sh
+++ b/uninstall_jarvik.sh
@@ -9,7 +9,7 @@ echo "🗑️ Odinstalace Jarvika..."
 
 # Kill running processes
 pkill -f "ollama serve" 2>/dev/null && echo "Zastaven ollama serve" || true
-pkill -f "ollama run $MODEL_NAME" 2>/dev/null && echo "Zastaven $MODEL_NAME" || true
+pkill -f "ollama run" 2>/dev/null && echo "Zastaveny modely" || true
 pkill -f "python3 main.py" 2>/dev/null && echo "Zastaven Flask" || true
 
 # Remove directories and logs


### PR DESCRIPTION
## Summary
- terminate any running models in uninstall script
- adjust output to say `Zastaveny modely`

## Testing
- `bash -n uninstall_jarvik.sh`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685cdb261aac832294bddde9e73f0759