### PR TITLE
Add knowledge reload API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ Jarvik exposes a few HTTP endpoints on the configured Flask port
 * `GET /memory/search?q=term` – search stored memory entries. When no query is
   provided, the last five entries are returned.
 * `GET /knowledge/search?q=term` – search the local knowledge base files.
+* `POST /knowledge/reload` – reload the knowledge base and return the number of loaded chunks.
 * `GET /model` – return the currently running model name.
 * `POST /model` – switch models by posting `{ "model": "name" }`.
 

--- a/main.py
+++ b/main.py
@@ -232,6 +232,15 @@ def knowledge_search():
     return jsonify(search_knowledge(query, knowledge_base))
 
 
+@app.route("/knowledge/reload", methods=["POST"])
+def knowledge_reload():
+    """Reload knowledge base files and return how many chunks were loaded."""
+    global knowledge_base
+    knowledge_base = load_knowledge(os.path.join(BASE_DIR, "knowledge"))
+    print("✅ Znalosti načteny.")
+    return jsonify({"status": "reloaded", "chunks": len(knowledge_base)})
+
+
 @app.route("/model", methods=["GET", "POST"])
 def model_route():
     """Get or switch the active model."""


### PR DESCRIPTION
## Summary
- implement `/knowledge/reload` POST endpoint
- log message when reloading knowledge
- document the new API in README

## Testing
- `python3 -m py_compile main.py rag_engine.py`

------
https://chatgpt.com/codex/tasks/task_b_685cdbe33e648322b0d3907072b77a50