### PR TITLE
Enable unlimited memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This repository contains scripts to run the Jarvik assistant locally. Gemma 2B
 from Ollama is the default model used by all helper scripts. You can switch
 models at any time via the web interface or by calling the `/model` endpoint.
 Alternatively set the `MODEL_NAME` environment variable when starting a script
-to run a different model. Jarvik keeps the entire conversation history unless
-you set the
-`MAX_MEMORY_ENTRIES` environment variable to limit how many exchanges are stored.
+to run a different model. Jarvik now keeps the entire conversation history by
+default. To enforce a limit, set the `MAX_MEMORY_ENTRIES` environment variable
+before launching.
 The Flask API listens on port `8010` by default, but you can override this using
 the `FLASK_PORT` environment variable.
 

--- a/main.py
+++ b/main.py
@@ -23,10 +23,11 @@ memory_path = os.path.join(BASE_DIR, "memory", "public.jsonl")
 os.makedirs(os.path.dirname(memory_path), exist_ok=True)
 open(memory_path, "a", encoding="utf-8").close()
 
-# Maximum number of lines to keep in the memory file. Set to 0 for unlimited.
-MAX_MEMORY_ENTRIES = int(os.getenv("MAX_MEMORY_ENTRIES", 0))
-if MAX_MEMORY_ENTRIES <= 0:
-    MAX_MEMORY_ENTRIES = None
+# Jarvik now keeps conversation history indefinitely.
+# To enforce a limit, set the ``MAX_MEMORY_ENTRIES`` environment variable
+# manually before launching the application.
+limit_env = os.getenv("MAX_MEMORY_ENTRIES")
+MAX_MEMORY_ENTRIES = int(limit_env) if limit_env and limit_env.isdigit() else None
 
 app = Flask(__name__)
 


### PR DESCRIPTION
## Summary
- remove memory cap for conversation log
- document unlimited history with optional `MAX_MEMORY_ENTRIES` override

## Testing
- `python3 -m py_compile main.py rag_engine.py`

------
https://chatgpt.com/codex/tasks/task_b_685cdf0d1d888322a6eb7a6b1075938a