### PR TITLE
Add configurable Ollama URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ to run a different model. Jarvik now keeps the entire conversation history by
 default. To enforce a limit, set the `MAX_MEMORY_ENTRIES` environment variable
 before launching.
 The Flask API listens on port `8010` by default, but you can override this using
-the `FLASK_PORT` environment variable.
+the `FLASK_PORT` environment variable. Set `OLLAMA_URL` to point at a remote
+Ollama instance if it is not running locally (defaults to
+`http://localhost:11434`).
 
 ## Installation
 

--- a/main.py
+++ b/main.py
@@ -15,6 +15,8 @@ import subprocess
 MODEL_NAME = os.getenv("MODEL_NAME", "gemma:2b")
 # Allow choosing the Flask port via environment variable
 FLASK_PORT = int(os.getenv("FLASK_PORT", 8010))
+# Base URL for the Ollama server
+OLLAMA_URL = os.getenv("OLLAMA_URL", "http://localhost:11434")
 
 # Set base directory relative to this file
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -91,7 +93,7 @@ def ask():
     try:
         import requests
         response = requests.post(
-            "http://localhost:11434/api/generate",
+            f"{OLLAMA_URL}/api/generate",
             json={"model": MODEL_NAME, "prompt": prompt, "stream": False}
         )
         response.raise_for_status()
@@ -151,7 +153,7 @@ def ask_file():
     try:
         import requests
         response = requests.post(
-            "http://localhost:11434/api/generate",
+            f"{OLLAMA_URL}/api/generate",
             json={"model": MODEL_NAME, "prompt": prompt, "stream": False},
         )
         response.raise_for_status()

--- a/manual
+++ b/manual
@@ -4,6 +4,8 @@ Tento krátký manuál popisuje základní kroky pro instalaci a spuštění Jar
 
 Ve výchozím nastavení je použit model `gemma:2b` z Ollamy. Model lze kdykoli změnit ve webovém rozhraní nebo voláním endpointu `/model`. V příkladech je předpokládána Gemma 2B, jiný model zvolíte nastavením proměnné `MODEL_NAME` při spouštění skriptů.
 Flask API naslouchá na portu `8010`, který lze změnit proměnnou `FLASK_PORT`.
+Pro vzdálenou Ollamu nastavte proměnnou `OLLAMA_URL` (výchozí
+`http://localhost:11434`).
 
 ## Instalace
 

--- a/start_jarvik.sh
+++ b/start_jarvik.sh
@@ -45,12 +45,12 @@ if ! pgrep -f "ollama serve" > /dev/null; then
   nohup ollama serve > ollama.log 2>&1 &
   # Počkej na zpřístupnění API
   for i in {1..10}; do
-    if curl -s http://localhost:11434/api/tags >/dev/null 2>&1; then
+    if curl -s ${OLLAMA_URL:-http://localhost:11434}/api/tags >/dev/null 2>&1; then
       break
     fi
     sleep 1
   done
-  if ! curl -s http://localhost:11434/api/tags >/dev/null 2>&1; then
+  if ! curl -s ${OLLAMA_URL:-http://localhost:11434}/api/tags >/dev/null 2>&1; then
     echo -e "${RED}❌ Ollama se nespustila, zkontrolujte ollama.log${NC}"
     exit 1
   fi

--- a/start_model.sh
+++ b/start_model.sh
@@ -23,12 +23,12 @@ if ! pgrep -f "ollama serve" > /dev/null; then
   echo -e "${GREEN}🚀 Spouštím Ollama...${NC}"
   nohup ollama serve > ollama.log 2>&1 &
   for i in {1..10}; do
-    if curl -s http://localhost:11434/api/tags >/dev/null 2>&1; then
+    if curl -s ${OLLAMA_URL:-http://localhost:11434}/api/tags >/dev/null 2>&1; then
       break
     fi
     sleep 1
   done
-  if ! curl -s http://localhost:11434/api/tags >/dev/null 2>&1; then
+  if ! curl -s ${OLLAMA_URL:-http://localhost:11434}/api/tags >/dev/null 2>&1; then
     echo -e "${RED}❌ Ollama se nespustila, zkontrolujte ollama.log${NC}"
     exit 1
   fi

--- a/start_ollama.sh
+++ b/start_ollama.sh
@@ -16,12 +16,12 @@ if ! pgrep -f "ollama serve" > /dev/null; then
   echo -e "${GREEN}🚀 Spouštím Ollama...${NC}"
   nohup ollama serve > ollama.log 2>&1 &
   for i in {1..10}; do
-    if curl -s http://localhost:11434/api/tags >/dev/null 2>&1; then
+    if curl -s ${OLLAMA_URL:-http://localhost:11434}/api/tags >/dev/null 2>&1; then
       break
     fi
     sleep 1
   done
-  if ! curl -s http://localhost:11434/api/tags >/dev/null 2>&1; then
+  if ! curl -s ${OLLAMA_URL:-http://localhost:11434}/api/tags >/dev/null 2>&1; then
     echo -e "${RED}❌ Ollama se nespustila, zkontrolujte ollama.log${NC}"
     exit 1
   fi


### PR DESCRIPTION
## Summary
- add `OLLAMA_URL` environment variable to main.py
- use the variable when sending requests to Ollama
- allow start scripts to override Ollama host
- document the new variable in README and manual

## Testing
- `python3 -m py_compile main.py rag_engine.py`
- `bash -n start_jarvik.sh start_model.sh start_ollama.sh`

------
https://chatgpt.com/codex/tasks/task_b_685ce73ced8883229de2bf75df740085