### PR TITLE
Improve search_knowledge handling

### DIFF
--- a/rag_engine.py
+++ b/rag_engine.py
@@ -1,5 +1,6 @@
 import os
 import glob
+import re
 from difflib import SequenceMatcher
 
 def load_txt_file(path):
@@ -49,19 +50,20 @@ def load_knowledge(folder):
 def search_knowledge(query, knowledge_chunks, threshold=0.6):
     """Return up to five knowledge chunks relevant to *query*.
 
-    A chunk is included when it contains the query substring or when the
-    similarity ratio computed via :class:`difflib.SequenceMatcher` exceeds the
-    given *threshold*.
+    A chunk is included when any word from the cleaned query appears in it or
+    when the similarity ratio computed via :class:`difflib.SequenceMatcher`
+    exceeds the given *threshold*.
     """
 
-    query_lower = query.lower()
-    matches = []
+    clean_query = re.sub(r"\W+", " ", query.lower())
+    query_words = [w for w in clean_query.split() if w]
 
+    matches = []
     for chunk in knowledge_chunks:
         chunk_lower = chunk.lower()
-        ratio = SequenceMatcher(None, query_lower, chunk_lower).ratio()
+        ratio = SequenceMatcher(None, clean_query, chunk_lower).ratio()
 
-        if query_lower in chunk_lower or ratio >= threshold:
+        if any(word in chunk_lower for word in query_words) or ratio >= threshold:
             matches.append((ratio, chunk[:500]))  # Shorten for the prompt
 
     matches.sort(key=lambda x: x[0], reverse=True)

--- a/tests/test_rag_engine.py
+++ b/tests/test_rag_engine.py
@@ -1,0 +1,31 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from rag_engine import search_knowledge
+
+
+def test_search_knowledge_word_match():
+    chunks = [
+        "This is a hello text",
+        "Another world piece",
+        "Completely unrelated",
+    ]
+    result = search_knowledge("hello world", chunks, threshold=0.9)
+    assert result == [
+        "Another world piece",
+        "This is a hello text",
+    ]
+
+
+def test_search_knowledge_sequence_ratio():
+    chunks = ["hello"]
+    result = search_knowledge("helo", chunks)
+    assert result == ["hello"]
+
+
+def test_search_knowledge_punctuation_removed():
+    chunks = ["hello world", "foo bar"]
+    result = search_knowledge("Hello, world!", chunks, threshold=1.1)
+    assert result == ["hello world"]


### PR DESCRIPTION
## Summary
- normalize queries when searching local knowledge
- match chunks when any query word is present or the fuzzy match ratio is high
- add unit tests for the search behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685ce89a35b88322887822ebf87bbd1b