### PR TITLE
Add RAG engine tests and README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,16 @@ Jarvik exposes a few HTTP endpoints on the configured Flask port
 * `GET /knowledge/search?q=term` – search the local knowledge base files.
 * `POST /knowledge/reload` – reload the knowledge base and return the number of loaded chunks.
 * `GET /model` – return the currently running model name.
+
 * `POST /model` – switch models by posting `{ "model": "name" }`.
+
+## Running Tests
+
+Unit tests live in the `tests/` directory. Execute them with:
+
+```bash
+pytest
+```
 
 ## License
 

--- a/tests/test_rag_engine.py
+++ b/tests/test_rag_engine.py
@@ -3,7 +3,39 @@ import sys
 import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-from rag_engine import search_knowledge
+from rag_engine import load_knowledge, search_knowledge
+
+
+@pytest.fixture
+def knowledge_dir(tmp_path):
+    """Create a temporary knowledge base with TXT, PDF and DOCX files."""
+    folder = tmp_path / "kb"
+    folder.mkdir()
+
+    # Always create a TXT file
+    (folder / "info.txt").write_text("TXT knowledge", encoding="utf-8")
+
+    # Create a PDF file when the required packages are available
+    try:
+        from fpdf import FPDF
+        pdf = FPDF()
+        pdf.add_page()
+        pdf.set_font("Arial", size=12)
+        pdf.cell(0, 10, "PDF knowledge")
+        pdf.output(str(folder / "info.pdf"))
+    except Exception:
+        pass
+
+    # Create a DOCX file when the required package is available
+    try:
+        from docx import Document
+        doc = Document()
+        doc.add_paragraph("DOCX knowledge")
+        doc.save(str(folder / "info.docx"))
+    except Exception:
+        pass
+
+    return folder
 
 
 def test_search_knowledge_word_match():
@@ -29,3 +61,35 @@ def test_search_knowledge_punctuation_removed():
     chunks = ["hello world", "foo bar"]
     result = search_knowledge("Hello, world!", chunks, threshold=1.1)
     assert result == ["hello world"]
+
+
+def test_load_knowledge(knowledge_dir):
+    chunks = load_knowledge(knowledge_dir)
+
+    assert "TXT knowledge" in chunks
+
+    if any(f.suffix == ".pdf" for f in knowledge_dir.iterdir()):
+        assert any("PDF knowledge" in c for c in chunks)
+
+    if any(f.suffix == ".docx" for f in knowledge_dir.iterdir()):
+        assert any("DOCX knowledge" in c for c in chunks)
+
+
+def test_load_knowledge_all_formats(knowledge_dir):
+    pytest.importorskip("PyPDF2")
+    pytest.importorskip("fpdf")
+    pytest.importorskip("docx")
+
+    chunks = load_knowledge(knowledge_dir)
+
+    assert any("PDF knowledge" in c for c in chunks)
+    assert any("DOCX knowledge" in c for c in chunks)
+
+
+def test_search_knowledge_czech_punctuation():
+    chunks = [
+        "N\u011bco o IPv6 protokolu.",
+        "Jin\u00fd text.",
+    ]
+    result = search_knowledge("n\u011bco o ipv6?", chunks)
+    assert result == ["N\u011bco o IPv6 protokolu."]


### PR DESCRIPTION
## Summary
- test knowledge loading for TXT, PDF and DOCX
- test search with punctuation and Unicode characters
- mention test suite in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685cebe1b1bc8322b0beae7115203d63